### PR TITLE
Support multi-variable heredoc lines

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -145,7 +145,9 @@ const rules = {
     seq(
       '<<<',
       $._heredoc_start,
+      opt(alias($._heredoc_start_newline, '\n')),
       choice.rep($._heredoc_body, $.variable, $.embedded_brace_expression),
+      opt(alias($._heredoc_end_newline, '\n')),
       $._heredoc_end,
     ),
 
@@ -1140,7 +1142,13 @@ module.exports = grammar({
 
   extras: $ => [/\s/, $.comment],
 
-  externals: $ => [$._heredoc_start, $._heredoc_body, $._heredoc_end],
+  externals: $ => [
+    $._heredoc_start,
+    $._heredoc_start_newline,
+    $._heredoc_body,
+    $._heredoc_end_newline,
+    $._heredoc_end,
+  ],
 
   supertypes: $ => [
     $._statement,

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -384,6 +384,23 @@
           "name": "_heredoc_start"
         },
         {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_heredoc_start_newline"
+              },
+              "named": false,
+              "value": "\n"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
           "type": "REPEAT",
           "content": {
             "type": "CHOICE",
@@ -402,6 +419,23 @@
               }
             ]
           }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_heredoc_end_newline"
+              },
+              "named": false,
+              "value": "\n"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         },
         {
           "type": "SYMBOL",
@@ -8203,7 +8237,15 @@
     },
     {
       "type": "SYMBOL",
+      "name": "_heredoc_start_newline"
+    },
+    {
+      "type": "SYMBOL",
       "name": "_heredoc_body"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_heredoc_end_newline"
     },
     {
       "type": "SYMBOL",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -3793,6 +3793,10 @@
     }
   },
   {
+    "type": "\n",
+    "named": false
+  },
+  {
     "type": "!",
     "named": false
   },
@@ -4194,11 +4198,11 @@
   },
   {
     "type": "float",
-    "named": true
+    "named": false
   },
   {
     "type": "float",
-    "named": false
+    "named": true
   },
   {
     "type": "for",
@@ -4366,11 +4370,11 @@
   },
   {
     "type": "string",
-    "named": false
+    "named": true
   },
   {
     "type": "string",
-    "named": true
+    "named": false
   },
   {
     "type": "super",

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -39,11 +39,19 @@ using std::string;
 
 enum TokenType {
   HEREDOC_START,
+  HEREDOC_START_NEWLINE,
   HEREDOC_BODY,
+  HEREDOC_END_NEWLINE,
   HEREDOC_END,
 };
 
-const char *TokenTypes[] = {"HEREDOC_START", "HEREDOC_BODY", "HEREDOC_END"};
+const char *TokenTypes[] = {
+    "HEREDOC_START",          //
+    "HEREDOC_START_NEWLINE",  //
+    "HEREDOC_BODY",           //
+    "HEREDOC_END_NEWLINE",    //
+    "HEREDOC_END",            //
+};
 
 static const char *str(int32_t chr) {
   switch (chr) {
@@ -70,61 +78,47 @@ static const char *str(int32_t chr) {
 
 struct Scanner {
   unsigned serialize(char *buffer) {
-    if (delimiter.length() + 1 >= TREE_SITTER_SERIALIZATION_BUFFER_SIZE) return 0;
+    if (delimiter.length() + 2 >= TREE_SITTER_SERIALIZATION_BUFFER_SIZE) return 0;
     buffer[0] = is_nowdoc;
     buffer[1] = did_start;
-    delimiter.copy(&buffer[2], delimiter.length());
-    return delimiter.length() + 2;
+    buffer[2] = did_end;
+    delimiter.copy(&buffer[3], delimiter.length());
+    return delimiter.length() + 3;
   }
 
   void deserialize(const char *buffer, unsigned length) {
     if (length == 0) {
       is_nowdoc = false;
+      did_start = false;
+      did_end = false;
       delimiter.clear();
     } else {
       is_nowdoc = buffer[0];
       did_start = buffer[1];
-      delimiter.assign(&buffer[2], &buffer[length]);
+      did_end = buffer[2];
+      delimiter.assign(&buffer[3], &buffer[length]);
     }
   }
 
+  /**
+   * Note: if we return false for a scan, variable value changes are overwritten with the values of
+   * the last successful scan. https://tree-sitter.github.io/tree-sitter/creating-parsers#serialize
+   */
   bool scan(TSLexer *lexer, const bool *expected) {
     print("\n> ");
-    if (expected[HEREDOC_END]) print("%s ", TokenTypes[HEREDOC_END]);
-    if (expected[HEREDOC_BODY]) print("%s ", TokenTypes[HEREDOC_BODY]);
     if (expected[HEREDOC_START]) print("%s ", TokenTypes[HEREDOC_START]);
+    if (expected[HEREDOC_START_NEWLINE]) print("%s ", TokenTypes[HEREDOC_START_NEWLINE]);
+    if (expected[HEREDOC_BODY]) print("%s ", TokenTypes[HEREDOC_BODY]);
+    if (expected[HEREDOC_END_NEWLINE]) print("%s ", TokenTypes[HEREDOC_END_NEWLINE]);
+    if (expected[HEREDOC_END]) print("%s ", TokenTypes[HEREDOC_END]);
     print("\n");
 
-    print("peek %s\n", str(peek()));
-
-    if ((expected[HEREDOC_BODY] || expected[HEREDOC_END]) && !delimiter.empty()) {
-      if (!did_start) {
-        //<<<HEREDOC   \n
-        //          ^^^ consume this whitespace
-        while (iswspace(peek()) && peek() != '\n') skip();
-      }
-
-      if (expected[HEREDOC_END] && scan_end(lexer)) {
-        delimiter.clear();
-        did_start = false;
-        is_nowdoc = false;
-
-        set(HEREDOC_END);
-        return true;
-      }
-
-      if (expected[HEREDOC_BODY] && scan_body(lexer)) {
-        set(HEREDOC_BODY);
-        return true;
-      }
+    if (expected[HEREDOC_BODY] || expected[HEREDOC_END]) {
+      return scan_body(lexer);
     }
 
     if (expected[HEREDOC_START]) {
-      if (scan_start(lexer)) {
-        did_start = false;
-        set(HEREDOC_START);
-        return true;
-      }
+      return scan_start(lexer);
     }
 
     return false;
@@ -163,120 +157,146 @@ struct Scanner {
       return false;
     }
 
-    return !delimiter.empty();
-  }
-
-  bool scan_end(TSLexer *lexer) {
-    print("scan end\n");
-
-    prefix.clear();
-
-    if (peek() == '\n') {
-      skip();
-      did_start = true;
-    } else {
+    // A valid delimiter must end with a newline with no whitespace in between.
+    if (peek() != '\n' || delimiter.empty()) {
       return false;
     }
 
-    while (
-        // Let `prefix` grow one character beyond `delimiter`.
-        prefix.length() <= delimiter.length() &&
+    set(HEREDOC_START);
+    stop();
+    next();
 
-        // clang-format off
-        peek() != ';' &&
-        peek() != '\n' &&
-        peek() != ',' &&
-        peek() != '$'
-        // clang-format on
-    ) {
-      prefix += peek();
-      next();
+    if (scan_delimiter(lexer)) {
+      if (peek() == ';') next();
+      if (peek() == '\n') {
+        // <<<EOF\n
+        // EOF;  ^^ able to detect did_end
+        did_end = true;
+      }
     }
 
-    print("pre %s ?= %s\n", prefix.c_str(), delimiter.c_str());
+    return true;
+  }
 
-    return prefix == delimiter;
+  bool scan_delimiter(TSLexer *lexer) {
+    for (unsigned long index = 0; index < delimiter.length(); index++) {
+      if (delimiter[index] == peek()) {
+        next();
+      } else {
+        return false;
+      }
+    }
+    return true;
   }
 
   bool scan_body(TSLexer *lexer) {
     print("scan body\n");
 
-    if (!did_start) {
-      if (peek() == '\n') {
-        skip();
-      } else {
+    bool did_advance = false;
+
+    for (;;) {
+      if (peek() == '\0') {
         return false;
       }
 
-      did_start = true;
-    }
-
-    if (!is_nowdoc && prefix.empty()) {
-      if (peek() == '{') next();
-      if (peek() == '$') {
+      if (peek() == '\\') {
         next();
-        if (is_identifier_start_char(peek())) {
-          return false;
-        }
+        next();
+        did_advance = true;
+        continue;
       }
-    }
 
-    for (;;) {
-      switch (peek()) {
-        case '\0': {
-          return false;
-        }
-
-        case '\\': {
+      if ((peek() == '{' || peek() == '$') && !is_nowdoc) {
+        stop();
+        if (peek() == '{') next();
+        if (peek() == '$') {
           next();
-          next();
-          break;
-        }
 
-        case '{': {
-          if (is_nowdoc) {
-            next();
-          } else {
-            stop();
-            next();
-
-            if (peek() == '$') {
-              return true;
+          if (is_identifier_start_char(peek())) {
+            if (did_advance) {
+              set(HEREDOC_BODY);
             }
+            return did_advance;
           }
-
-          break;
         }
 
-        case '$': {
-          if (is_nowdoc) {
-            next();
-          } else {
-            stop();
-            next();
+        did_advance = true;
+        continue;
+      }
 
-            if (is_identifier_start_char(peek())) {
-              return true;
-            }
-          }
-          break;
-        }
-
-        case '\n': {
+      if (did_end || peek() == '\n') {
+        if (did_advance) {
+          // <<<EOF
+          // x     \n
+          // EOF;  ^^ able to detect did_end
           stop();
+          next();
+        } else if (peek() == '\n') {
+          if (did_end) {
+            // Detected did_end in a previous HEREDOC_BODY or HEREDOC_START scan. Can skip newline.
+            //
+            // <<<EOF\n
+            // EOF;  ^^ detected did_end during HEREDOC_START scan
+            ///
+            // <<<EOF
+            // x     \n
+            // EOF;  ^^ detected did_end during HEREDOC_BODY scan
+            skip();
+          } else {
+            // Did not detect did_end in a previous scan. Newline could be HEREDOC_START_NEWLINE,
+            // HEREDOC_BODY, HEREDOC_END_NEWLINE.
+            //
+            // <<<EOF\n
+            // x     ^^ HEREDOC_START_NEWLINE
+            // EOF;
+            //
+            // <<<EOF
+            // $variable\n
+            // x        ^^ HEREDOC_BODY
+            // EOF;
+            //
+            // <<<EOF
+            // $variable\n
+            // EOF;     ^^ HEREDOC_END_NEWLINE
+            next();
+            stop();
+          }
+        }
 
-          if (scan_end(lexer)) {
+        if (scan_delimiter(lexer)) {
+          if (!did_advance && did_end) stop();
+
+          if (peek() == ';') next();
+          if (peek() == '\n') {
+            if (did_advance) {
+              set(HEREDOC_BODY);
+              did_start = true;
+              did_end = true;
+            } else if (did_end) {
+              set(HEREDOC_END);
+              delimiter.clear();
+              is_nowdoc = false;
+              did_start = false;
+              did_end = false;
+            } else {
+              set(HEREDOC_END_NEWLINE);
+              did_start = true;
+              did_end = true;
+            }
             return true;
           }
-
-          break;
+        } else if (!did_start && !did_advance) {
+          set(HEREDOC_START_NEWLINE);
+          did_start = true;
+          return true;
         }
 
-        default: {
-          next();
-          break;
-        }
+        did_advance = true;
+        continue;
       }
+
+      next();
+      did_advance = true;
     }
   }
 
@@ -286,9 +306,9 @@ struct Scanner {
   }
 
   string delimiter;
-  string prefix;
   bool is_nowdoc;
   bool did_start;
+  bool did_end;
 };
 
 }  // namespace

--- a/test/cases/literals/heredoc-brace.exp
+++ b/test/cases/literals/heredoc-brace.exp
@@ -1,7 +1,8 @@
 (script
   (expression_statement
     (heredoc
-      (variable)
+      (embedded_brace_expression
+        (variable))
       (embedded_brace_expression
         (variable))
       (embedded_brace_expression

--- a/test/cases/literals/heredoc-variable.exp
+++ b/test/cases/literals/heredoc-variable.exp
@@ -1,4 +1,4 @@
-(script 
+(script
   (comment)
   (comment)
   (expression_statement
@@ -6,4 +6,20 @@
       (variable)))
   (expression_statement
     (heredoc
+      (variable)))
+  (expression_statement
+    (heredoc
+      (variable)))
+  (expression_statement
+    (heredoc
+      (variable)))
+  (expression_statement
+    (heredoc
+      (variable)))
+  (expression_statement
+    (heredoc
+      (variable)))
+  (expression_statement
+    (heredoc
+      (variable)
       (variable))))

--- a/test/cases/literals/heredoc-variable.hack
+++ b/test/cases/literals/heredoc-variable.hack
@@ -6,5 +6,27 @@ r$var
 EOF;
 
 <<<EOT
-	$ÿ
+ $ÿ
 EOT;
+
+<<<EOF
+E$var
+EOF;
+
+<<<EOF
+$var
+EOF;
+
+<<<EOF
+$var
+
+EOF;
+
+<<<EOF
+$var
+abc
+EOF;
+
+<<<EOF
+$var x $var
+EOF;


### PR DESCRIPTION
# Description
## did_start
Heredocs that start with a variable _and_ have multiple variables on the same line cause the scanner to incorrectly parse the heredoc.

```hack
$x = <<<EOF
$var x $var
    ^ interpreted as whitespace between <<<EOF and first \n
EOF;
```

Because the heredoc starts with a variable, we do not successfully scan a heredoc body — we return false from `scan` and `scan_body` for the first `HEREDOC_BODY` scan. This is expected, but this also means `did_start` is reset to false on the following scan. If `did_start` is false, the `scan_body` function [expects the scan to start at a newline](https://github.com/slackhq/tree-sitter-hack/blob/5f50f4c6cbb280ac053839c2e009d87e81d65244/src/scanner.cc#L204-L212) to be a successful scan. So the scanner get's stuck at the character `x`.

### `$._heredoc_start_newline`
The fix is to add a new external rule (`$._heredoc_start_newline`) that captures the first heredoc newline. This let's us skip the first newline and know that any subsequent newlines are part of the body (except for the final newline, see below).

Another fix could be to make the newline character a part of the `$.heredoc_start` node itself. This would mean we don't need a new rule and 1 less `scan` call. It might also result in a simpler scanner implementation, but it's technically not accurate — i.e. the heredoc delimiter doesn't _actually_ contain a newline (and it _can't_ contain a newline). Yes the difference is verging on trivial, but in my opinion having a separate rule is clearer and potentially avoids subtle bugs in downstream dependencies.

## did_end
While fixing the original bug I also noticed that heredocs that ended in a variable resulted in an empty `$.heredoc_body` nodes — i.e. starting and ending offsets were the same.

```hack
$x = <<<EOF
$var\n 
     ^ could be part of the heredoc body or could be the final heredoc newline (whitespace)
EOF;
```

During a scan, if we find a newline, we don't know whether to capture it or skip it until we check if the following line is a `$.heredoc_end`. But by the time we scan for a `$.heredoc_end` we can't change whether the newline is captured or skipped.

### `$._heredoc_end_newline`
We can skip it, but if the next line turns out to be a `$.heredoc_body` we miss a newline that's supposed to be part fo the content. 

We can capture it, but if the next line turns out to be a `$.heredoc_end` we either need to include that newline as part of the `$.heredoc_end` itself (similar problem to`$.heredoc_start`) or return a match for an empty`$.heredoc_body` (what exists today) so that the following scan knows to skip the newline and match `$.heredoc_end`.

These alternatives are arguably good enough, but if we can be scan a heredoc body without caveats and warning labels, I think we should do that.