### PR TITLE
Track corpus

### DIFF
--- a/.github/workflows/validate.sh
+++ b/.github/workflows/validate.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+if [ -n "$(git status --porcelain)" ]; then
+    exit 1
+fi

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           node-version: 14
       - run: npm install
-      - run: npm build
+      - run: npm run build
       - name: Generate corpus
         run: "${GITHUB_WORKSPACE}/bin/generate-corpus"
         shell: bash

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,24 @@
+name: validate
+on:
+  pull_request:
+    branches:
+      - "**"
+  push:
+    branches:
+      - "main"
+jobs:
+  check-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14
+      - run: npm install
+      - run: npm build
+      - name: Generate corpus
+        run: "${GITHUB_WORKSPACE}/bin/generate-corpus"
+        shell: bash
+      - name: Check for changes
+        run: "${GITHUB_WORKSPACE}/.github/workflows/validate.sh"
+        shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,4 @@ examples
 package-lock.json
 tmp
 
-# Source test files in test/cases. We can ignore test/corpus.
-test/corpus/*
-!test/corpus/.empty
-
 test/cases/**/*.json

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1,5 +1,9 @@
 {
   "name": "hack",
+
+
+
+  
   "word": "identifier",
   "rules": {
     "script": {

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1,9 +1,5 @@
 {
   "name": "hack",
-
-
-
-  
   "word": "identifier",
   "rules": {
     "script": {

--- a/test/corpus/declarations.txt
+++ b/test/corpus/declarations.txt
@@ -2,6 +2,8 @@
 Async functions
 ==========================
 
+async function func0(): void {}
+
 async function func1<T1 as int>() {}
 
 async ($x) ==> $x + 1;

--- a/test/corpus/declarations.txt
+++ b/test/corpus/declarations.txt
@@ -1,0 +1,2123 @@
+==========================
+Async functions
+==========================
+
+async function func0(): void {}
+
+async function func1<T1 as int>() {}
+
+async ($x) ==> $x + 1;
+
+---
+
+(script
+  (function_declaration
+    (async_modifier)
+    name: (identifier)
+    (parameters)
+    return_type: (type_specifier)
+    body: (compound_statement))
+  (function_declaration
+    (async_modifier)
+    name: (identifier)
+    (type_parameters
+      (type_parameter
+        name: (identifier)
+        constraint_type: (type_specifier)))
+    (parameters)
+    body: (compound_statement))
+  (expression_statement
+    (lambda_expression
+      (async_modifier)
+      (parameters
+        (parameter
+          name: (variable)))
+      body: (binary_expression
+        left: (variable)
+        right: (integer)))))
+
+==========================
+Attribute
+==========================
+
+<<Attribute, Attribute(1, 2),>>
+class C {
+  <<Attribute, Attribute(1, 2,)>>
+  function method() {}
+}
+
+<<Attribute(C,), Attribute>>
+function func() {
+}
+
+---
+
+(script
+  (class_declaration
+    (attribute_modifier
+      (qualified_identifier
+        (identifier))
+      (qualified_identifier
+        (identifier))
+      (arguments
+        (argument
+          (integer))
+        (argument
+          (integer))))
+    name: (identifier)
+    body: (member_declarations
+      (method_declaration
+        (attribute_modifier
+          (qualified_identifier
+            (identifier))
+          (qualified_identifier
+            (identifier))
+          (arguments
+            (argument
+              (integer))
+            (argument
+              (integer))))
+        name: (identifier)
+        (parameters)
+        body: (compound_statement))))
+  (function_declaration
+    (attribute_modifier
+      (qualified_identifier
+        (identifier))
+      (arguments
+        (argument
+          (qualified_identifier
+            (identifier))))
+      (qualified_identifier
+        (identifier)))
+    name: (identifier)
+    (parameters)
+    body: (compound_statement)))
+
+==========================
+Attribute function
+==========================
+
+function func(<<__Soft>> int $int): <<__Soft>> int {}
+
+---
+
+(script
+  (function_declaration
+    name: (identifier)
+    (parameters
+      (parameter
+        (attribute_modifier
+          (qualified_identifier
+            (identifier)))
+        type: (type_specifier)
+        name: (variable)))
+    (attribute_modifier
+      (qualified_identifier
+        (identifier)))
+    return_type: (type_specifier)
+    body: (compound_statement)))
+
+==========================
+Attribute type
+==========================
+
+<<A1>>
+newtype T1 = ?shape(
+  ?'int' => int
+);
+
+<<A3(1), A2(2,3,)>>
+type T2 = (function(T1): string);
+
+<<A4(1), A5, A6(1,3,4)>>
+newtype T3 as int = int;
+
+---
+
+(script
+  (alias_declaration
+    (attribute_modifier
+      (qualified_identifier
+        (identifier)))
+    (identifier)
+    (shape_type_specifier
+      (nullable_modifier)
+      (field_specifier
+        (optional_modifier)
+        (string)
+        (type_specifier))))
+  (alias_declaration
+    (attribute_modifier
+      (qualified_identifier
+        (identifier))
+      (arguments
+        (argument
+          (integer)))
+      (qualified_identifier
+        (identifier))
+      (arguments
+        (argument
+          (integer))
+        (argument
+          (integer))))
+    (identifier)
+    (function_type_specifier
+      (type_specifier
+        (qualified_identifier
+          (identifier)))
+      return_type: (type_specifier)))
+  (alias_declaration
+    (attribute_modifier
+      (qualified_identifier
+        (identifier))
+      (arguments
+        (argument
+          (integer)))
+      (qualified_identifier
+        (identifier))
+      (qualified_identifier
+        (identifier))
+      (arguments
+        (argument
+          (integer))
+        (argument
+          (integer))
+        (argument
+          (integer))))
+    (identifier)
+    as: (type_specifier)
+    (type_specifier)))
+
+==========================
+Attribute type parameter
+==========================
+
+class C<<<Reify>> reify T> {}
+
+function func<<<Reify>> T>(): void {}
+
+---
+
+(script
+  (class_declaration
+    name: (identifier)
+    (type_parameters
+      (type_parameter
+        (attribute_modifier
+          (qualified_identifier
+            (identifier)))
+        (reify_modifier)
+        name: (identifier)))
+    body: (member_declarations))
+  (function_declaration
+    name: (identifier)
+    (type_parameters
+      (type_parameter
+        (attribute_modifier
+          (qualified_identifier
+            (identifier)))
+        name: (identifier)))
+    (parameters)
+    return_type: (type_specifier)
+    body: (compound_statement)))
+
+==========================
+Class
+==========================
+
+<<Attribute(R::class), Attribute(1,),>>
+class F<Ta as A, Tb super B<A, C>> extends B implements A\B<A, C>, C\D {
+  function method<Ta as A, Tb super B>(): Tc {}
+}
+
+---
+
+(script
+  (class_declaration
+    (attribute_modifier
+      (qualified_identifier
+        (identifier))
+      (arguments
+        (argument
+          (scoped_identifier
+            (qualified_identifier
+              (identifier))
+            (identifier))))
+      (qualified_identifier
+        (identifier))
+      (arguments
+        (argument
+          (integer))))
+    name: (identifier)
+    (type_parameters
+      (type_parameter
+        name: (identifier)
+        constraint_type: (type_specifier
+          (qualified_identifier
+            (identifier))))
+      (type_parameter
+        name: (identifier)
+        constraint_type: (type_specifier
+          (qualified_identifier
+            (identifier))
+          (type_arguments
+            (type_specifier
+              (qualified_identifier
+                (identifier)))
+            (type_specifier
+              (qualified_identifier
+                (identifier)))))))
+    (extends_clause
+      (type_specifier
+        (qualified_identifier
+          (identifier))))
+    (implements_clause
+      (type_specifier
+        (qualified_identifier
+          (identifier)
+          (identifier))
+        (type_arguments
+          (type_specifier
+            (qualified_identifier
+              (identifier)))
+          (type_specifier
+            (qualified_identifier
+              (identifier)))))
+      (type_specifier
+        (qualified_identifier
+          (identifier)
+          (identifier))))
+    body: (member_declarations
+      (method_declaration
+        name: (identifier)
+        (type_parameters
+          (type_parameter
+            name: (identifier)
+            constraint_type: (type_specifier
+              (qualified_identifier
+                (identifier))))
+          (type_parameter
+            name: (identifier)
+            constraint_type: (type_specifier
+              (qualified_identifier
+                (identifier)))))
+        (parameters)
+        return_type: (type_specifier
+          (qualified_identifier
+            (identifier)))
+        body: (compound_statement)))))
+
+==========================
+Class const
+==========================
+
+abstract class C {
+  abstract const A\B C01;
+  const A\B C02 = A\B::C0;
+  const C03 = A\B::C0;
+
+  const int C1 = 1;
+  const int C2 = 1, C3 = 1;
+  const C4 = 1;
+  const C5 = 1, C6 = 1;
+
+  abstract const int C7;
+  abstract const int C8, C9;
+  abstract const CA;
+  abstract const CB, CC;
+}
+
+---
+
+(script
+  (class_declaration
+    (abstract_modifier)
+    name: (identifier)
+    body: (member_declarations
+      (const_declaration
+        (abstract_modifier)
+        type: (type_specifier
+          (qualified_identifier
+            (identifier)
+            (identifier)))
+        (const_declarator
+          name: (identifier)))
+      (const_declaration
+        type: (type_specifier
+          (qualified_identifier
+            (identifier)
+            (identifier)))
+        (const_declarator
+          name: (identifier)
+          value: (scoped_identifier
+            (qualified_identifier
+              (identifier)
+              (identifier))
+            (identifier))))
+      (const_declaration
+        (const_declarator
+          name: (identifier)
+          value: (scoped_identifier
+            (qualified_identifier
+              (identifier)
+              (identifier))
+            (identifier))))
+      (const_declaration
+        type: (type_specifier)
+        (const_declarator
+          name: (identifier)
+          value: (integer)))
+      (const_declaration
+        type: (type_specifier)
+        (const_declarator
+          name: (identifier)
+          value: (integer))
+        (const_declarator
+          name: (identifier)
+          value: (integer)))
+      (const_declaration
+        (const_declarator
+          name: (identifier)
+          value: (integer)))
+      (const_declaration
+        (const_declarator
+          name: (identifier)
+          value: (integer))
+        (const_declarator
+          name: (identifier)
+          value: (integer)))
+      (const_declaration
+        (abstract_modifier)
+        type: (type_specifier)
+        (const_declarator
+          name: (identifier)))
+      (const_declaration
+        (abstract_modifier)
+        type: (type_specifier)
+        (const_declarator
+          name: (identifier))
+        (const_declarator
+          name: (identifier)))
+      (const_declaration
+        (abstract_modifier)
+        (const_declarator
+          name: (identifier)))
+      (const_declaration
+        (abstract_modifier)
+        (const_declarator
+          name: (identifier))
+        (const_declarator
+          name: (identifier))))))
+
+==========================
+Class parameter visibility
+==========================
+
+class C {
+  public function __construct(<<__Soft>> private int $prop = 1, string ...$name) {}
+}
+
+---
+
+(script
+  (class_declaration
+    name: (identifier)
+    body: (member_declarations
+      (method_declaration
+        (visibility_modifier)
+        name: (identifier)
+        (parameters
+          (parameter
+            (attribute_modifier
+              (qualified_identifier
+                (identifier)))
+            (visibility_modifier)
+            type: (type_specifier)
+            name: (variable)
+            default_value: (integer))
+          (parameter
+            type: (type_specifier)
+            (variadic_modifier)
+            name: (variable)))
+        body: (compound_statement)))))
+
+==========================
+Class type parameters
+==========================
+
+abstract final class F<Ta as A, Tb super B<A, C>> extends B implements A\B<A, C>, C\D {
+  function method<Ta as A, Tb super B>(): Tc {}
+}
+
+---
+
+(script
+  (class_declaration
+    (abstract_modifier)
+    (final_modifier)
+    name: (identifier)
+    (type_parameters
+      (type_parameter
+        name: (identifier)
+        constraint_type: (type_specifier
+          (qualified_identifier
+            (identifier))))
+      (type_parameter
+        name: (identifier)
+        constraint_type: (type_specifier
+          (qualified_identifier
+            (identifier))
+          (type_arguments
+            (type_specifier
+              (qualified_identifier
+                (identifier)))
+            (type_specifier
+              (qualified_identifier
+                (identifier)))))))
+    (extends_clause
+      (type_specifier
+        (qualified_identifier
+          (identifier))))
+    (implements_clause
+      (type_specifier
+        (qualified_identifier
+          (identifier)
+          (identifier))
+        (type_arguments
+          (type_specifier
+            (qualified_identifier
+              (identifier)))
+          (type_specifier
+            (qualified_identifier
+              (identifier)))))
+      (type_specifier
+        (qualified_identifier
+          (identifier)
+          (identifier))))
+    body: (member_declarations
+      (method_declaration
+        name: (identifier)
+        (type_parameters
+          (type_parameter
+            name: (identifier)
+            constraint_type: (type_specifier
+              (qualified_identifier
+                (identifier))))
+          (type_parameter
+            name: (identifier)
+            constraint_type: (type_specifier
+              (qualified_identifier
+                (identifier)))))
+        (parameters)
+        return_type: (type_specifier
+          (qualified_identifier
+            (identifier)))
+        body: (compound_statement)))))
+
+==========================
+Class where
+==========================
+
+class C <T1> extends B<T2> implements A<T3> where T2 = T3 {
+  private function __construct(T1 $param) where ?T1 super vec<int>, {}
+}
+
+---
+
+(script
+  (class_declaration
+    name: (identifier)
+    (type_parameters
+      (type_parameter
+        name: (identifier)))
+    (extends_clause
+      (type_specifier
+        (qualified_identifier
+          (identifier))
+        (type_arguments
+          (type_specifier
+            (qualified_identifier
+              (identifier))))))
+    (implements_clause
+      (type_specifier
+        (qualified_identifier
+          (identifier))
+        (type_arguments
+          (type_specifier
+            (qualified_identifier
+              (identifier))))))
+    (where_clause
+      (where_constraint
+        constraint_left_type: (type_specifier
+          (qualified_identifier
+            (identifier)))
+        constraint_right_type: (type_specifier
+          (qualified_identifier
+            (identifier)))))
+    body: (member_declarations
+      (method_declaration
+        (visibility_modifier)
+        name: (identifier)
+        (parameters
+          (parameter
+            type: (type_specifier
+              (qualified_identifier
+                (identifier)))
+            name: (variable)))
+        (where_clause
+          (where_constraint
+            constraint_left_type: (type_specifier
+              (nullable_modifier)
+              (qualified_identifier
+                (identifier)))
+            constraint_right_type: (type_specifier
+              (type_arguments
+                (type_specifier)))))
+        body: (compound_statement)))))
+
+==========================
+Const
+==========================
+
+const int C1 = 1;
+const int C2 = 1, C3 = 1;
+const C4 = 1;
+const C5 = 1, C6 = 1;
+
+---
+
+(script
+  (const_declaration
+    type: (type_specifier)
+    (const_declarator
+      name: (identifier)
+      value: (integer)))
+  (const_declaration
+    type: (type_specifier)
+    (const_declarator
+      name: (identifier)
+      value: (integer))
+    (const_declarator
+      name: (identifier)
+      value: (integer)))
+  (const_declaration
+    (const_declarator
+      name: (identifier)
+      value: (integer)))
+  (const_declaration
+    (const_declarator
+      name: (identifier)
+      value: (integer))
+    (const_declarator
+      name: (identifier)
+      value: (integer))))
+
+==========================
+Const keyword
+==========================
+
+// Kinda wish this wasn't allowed. Seems like asking for trouble.
+
+const type = 1;
+const newtype = 1;
+
+// 🤦
+const int int = 1;
+
+const bool = 1;
+const float = 1;
+const int = 1;
+const string = 1;
+const arraykey = 1;
+const void = 1;
+const nonnull = 1;
+const null = 1;
+const mixed = 1;
+const dynamic = 1;
+const noreturn = 1;
+
+const array = 1;
+const varray = 1;
+const darray = 1;
+const vec = 1;
+const dict = 1;
+const keyset = 1;
+
+const tuple = 1;
+const shape = 1;
+
+---
+
+(script
+  (comment)
+  (const_declaration
+    (const_declarator
+      name: (identifier)
+      value: (integer)))
+  (const_declaration
+    (const_declarator
+      name: (identifier)
+      value: (integer)))
+  (comment)
+  (const_declaration
+    type: (type_specifier)
+    (const_declarator
+      name: (identifier)
+      value: (integer)))
+  (const_declaration
+    (const_declarator
+      name: (identifier)
+      value: (integer)))
+  (const_declaration
+    (const_declarator
+      name: (identifier)
+      value: (integer)))
+  (const_declaration
+    (const_declarator
+      name: (identifier)
+      value: (integer)))
+  (const_declaration
+    (const_declarator
+      name: (identifier)
+      value: (integer)))
+  (const_declaration
+    (const_declarator
+      name: (identifier)
+      value: (integer)))
+  (const_declaration
+    (const_declarator
+      name: (identifier)
+      value: (integer)))
+  (const_declaration
+    (const_declarator
+      name: (identifier)
+      value: (integer)))
+  (const_declaration
+    (const_declarator
+      name: (identifier)
+      value: (integer)))
+  (const_declaration
+    (const_declarator
+      name: (identifier)
+      value: (integer)))
+  (const_declaration
+    (const_declarator
+      name: (identifier)
+      value: (integer)))
+  (const_declaration
+    (const_declarator
+      name: (identifier)
+      value: (integer)))
+  (const_declaration
+    (const_declarator
+      name: (identifier)
+      value: (integer)))
+  (const_declaration
+    (const_declarator
+      name: (identifier)
+      value: (integer)))
+  (const_declaration
+    (const_declarator
+      name: (identifier)
+      value: (integer)))
+  (const_declaration
+    (const_declarator
+      name: (identifier)
+      value: (integer)))
+  (const_declaration
+    (const_declarator
+      name: (identifier)
+      value: (integer)))
+  (const_declaration
+    (const_declarator
+      name: (identifier)
+      value: (integer)))
+  (const_declaration
+    (const_declarator
+      name: (identifier)
+      value: (integer)))
+  (const_declaration
+    (const_declarator
+      name: (identifier)
+      value: (integer))))
+
+==========================
+Empty function
+==========================
+
+namespace {
+  <<__PHPStdLib, __Pure>>
+  function is_bool($var): bool;
+  <<__PHPStdLib, __Pure>>
+  function is_int($var): bool;
+}
+
+---
+
+(script
+  (namespace_declaration
+    body: (compound_statement
+      (function_declaration
+        (attribute_modifier
+          (qualified_identifier
+            (identifier))
+          (qualified_identifier
+            (identifier)))
+        name: (identifier)
+        (parameters
+          (parameter
+            name: (variable)))
+        return_type: (type_specifier))
+      (function_declaration
+        (attribute_modifier
+          (qualified_identifier
+            (identifier))
+          (qualified_identifier
+            (identifier)))
+        name: (identifier)
+        (parameters
+          (parameter
+            name: (variable)))
+        return_type: (type_specifier)))))
+
+==========================
+Enum
+==========================
+
+enum Enum: int {}
+
+<<Beenum>>
+enum Enum : int {
+  F1 = 1;
+  F2 = 8;
+  F3 = C::CONST;
+  F4 = 'a'.'b';
+}
+
+---
+
+(script
+  (enum_declaration
+    name: (identifier)
+    type: (type_specifier))
+  (enum_declaration
+    (attribute_modifier
+      (qualified_identifier
+        (identifier)))
+    name: (identifier)
+    type: (type_specifier)
+    (enumerator
+      (identifier)
+      (integer))
+    (enumerator
+      (identifier)
+      (integer))
+    (enumerator
+      (identifier)
+      (scoped_identifier
+        (qualified_identifier
+          (identifier))
+        (identifier)))
+    (enumerator
+      (identifier)
+      (binary_expression
+        left: (string)
+        right: (string)))))
+
+==========================
+Enum type constraint
+==========================
+
+enum Enum: int as int {
+  F1 = 1;
+  F2 = 8;
+}
+
+---
+
+(script
+  (enum_declaration
+    name: (identifier)
+    type: (type_specifier)
+    as: (type_specifier)
+    (enumerator
+      (identifier)
+      (integer))
+    (enumerator
+      (identifier)
+      (integer))))
+
+==========================
+Function
+==========================
+
+function func0(): void {}
+
+function func1(...) {}
+
+function func2($arg) {}
+
+function func3(int $arg) {}
+
+function func4(int $arg): void {}
+
+function func5(int $arg1, bool $arg2): void {}
+
+---
+
+(script
+  (function_declaration
+    name: (identifier)
+    (parameters)
+    return_type: (type_specifier)
+    body: (compound_statement))
+  (function_declaration
+    name: (identifier)
+    (parameters
+      (variadic_modifier))
+    body: (compound_statement))
+  (function_declaration
+    name: (identifier)
+    (parameters
+      (parameter
+        name: (variable)))
+    body: (compound_statement))
+  (function_declaration
+    name: (identifier)
+    (parameters
+      (parameter
+        type: (type_specifier)
+        name: (variable)))
+    body: (compound_statement))
+  (function_declaration
+    name: (identifier)
+    (parameters
+      (parameter
+        type: (type_specifier)
+        name: (variable)))
+    return_type: (type_specifier)
+    body: (compound_statement))
+  (function_declaration
+    name: (identifier)
+    (parameters
+      (parameter
+        type: (type_specifier)
+        name: (variable))
+      (parameter
+        type: (type_specifier)
+        name: (variable)))
+    return_type: (type_specifier)
+    body: (compound_statement)))
+
+==========================
+Function inout
+==========================
+
+function func(<<__Soft>> inout int $arg1, inout int $arg2) {}
+
+---
+
+(script
+  (function_declaration
+    name: (identifier)
+    (parameters
+      (parameter
+        (attribute_modifier
+          (qualified_identifier
+            (identifier)))
+        (inout_modifier)
+        type: (type_specifier)
+        name: (variable))
+      (parameter
+        (inout_modifier)
+        type: (type_specifier)
+        name: (variable)))
+    body: (compound_statement)))
+
+==========================
+Function soft variadic
+==========================
+
+function func(<<__Soft>> int ...$arg1) {}
+
+---
+
+(script
+  (function_declaration
+    name: (identifier)
+    (parameters
+      (parameter
+        (attribute_modifier
+          (qualified_identifier
+            (identifier)))
+        type: (type_specifier)
+        (variadic_modifier)
+        name: (variable)))
+    body: (compound_statement)))
+
+==========================
+Function type parameters
+==========================
+
+function func<Ta, Tb as int, Td super int>(): void {}
+
+---
+
+(script
+  (function_declaration
+    name: (identifier)
+    (type_parameters
+      (type_parameter
+        name: (identifier))
+      (type_parameter
+        name: (identifier)
+        constraint_type: (type_specifier))
+      (type_parameter
+        name: (identifier)
+        constraint_type: (type_specifier)))
+    (parameters)
+    return_type: (type_specifier)
+    body: (compound_statement)))
+
+==========================
+Function type specifier
+==========================
+
+type func = (function(int, ?string,): string);
+
+function func((function(inout int): string) $func): (function(int): string) {}
+
+---
+
+(script
+  (alias_declaration
+    (identifier)
+    (function_type_specifier
+      (type_specifier)
+      (type_specifier
+        (nullable_modifier))
+      return_type: (type_specifier)))
+  (function_declaration
+    name: (identifier)
+    (parameters
+      (parameter
+        type: (function_type_specifier
+          (inout_modifier)
+          (type_specifier)
+          return_type: (type_specifier))
+        name: (variable)))
+    return_type: (function_type_specifier
+      (type_specifier)
+      return_type: (type_specifier))
+    body: (compound_statement)))
+
+==========================
+Function where
+==========================
+
+function func1<T>(): T where T as int {}
+
+function func2<T>(): T where vec<T> = int {}
+
+---
+
+(script
+  (function_declaration
+    name: (identifier)
+    (type_parameters
+      (type_parameter
+        name: (identifier)))
+    (parameters)
+    return_type: (type_specifier
+      (qualified_identifier
+        (identifier)))
+    (where_clause
+      (where_constraint
+        constraint_left_type: (type_specifier
+          (qualified_identifier
+            (identifier)))
+        constraint_right_type: (type_specifier)))
+    body: (compound_statement))
+  (function_declaration
+    name: (identifier)
+    (type_parameters
+      (type_parameter
+        name: (identifier)))
+    (parameters)
+    return_type: (type_specifier
+      (qualified_identifier
+        (identifier)))
+    (where_clause
+      (where_constraint
+        constraint_left_type: (type_specifier
+          (type_arguments
+            (type_specifier
+              (qualified_identifier
+                (identifier)))))
+        constraint_right_type: (type_specifier)))
+    body: (compound_statement)))
+
+==========================
+Function where tricky
+==========================
+
+function func1<T>() where T = int, {}
+
+function func2<T>() where ?vec<T> = int, T super int {}
+
+# Optional comma. Why tho?
+function func3<T>() where ?vec<T> = int T super int {}
+
+---
+
+(script
+  (function_declaration
+    name: (identifier)
+    (type_parameters
+      (type_parameter
+        name: (identifier)))
+    (parameters)
+    (where_clause
+      (where_constraint
+        constraint_left_type: (type_specifier
+          (qualified_identifier
+            (identifier)))
+        constraint_right_type: (type_specifier)))
+    body: (compound_statement))
+  (function_declaration
+    name: (identifier)
+    (type_parameters
+      (type_parameter
+        name: (identifier)))
+    (parameters)
+    (where_clause
+      (where_constraint
+        constraint_left_type: (type_specifier
+          (nullable_modifier)
+          (type_arguments
+            (type_specifier
+              (qualified_identifier
+                (identifier)))))
+        constraint_right_type: (type_specifier))
+      (where_constraint
+        constraint_left_type: (type_specifier
+          (qualified_identifier
+            (identifier)))
+        constraint_right_type: (type_specifier)))
+    body: (compound_statement))
+  (comment)
+  (function_declaration
+    name: (identifier)
+    (type_parameters
+      (type_parameter
+        name: (identifier)))
+    (parameters)
+    (where_clause
+      (where_constraint
+        constraint_left_type: (type_specifier
+          (nullable_modifier)
+          (type_arguments
+            (type_specifier
+              (qualified_identifier
+                (identifier)))))
+        constraint_right_type: (type_specifier))
+      (where_constraint
+        constraint_left_type: (type_specifier
+          (qualified_identifier
+            (identifier)))
+        constraint_right_type: (type_specifier)))
+    body: (compound_statement)))
+
+==========================
+Interface
+==========================
+
+<<Attribute(R::class), Attribute(1,),>>
+interface F<Ta as A, Tb super B<A, C>> extends B, A\B<A, C>, C\D {
+  function method<Ta as A, Tb super B>(): Tc {}
+}
+
+---
+
+(script
+  (interface_declaration
+    (attribute_modifier
+      (qualified_identifier
+        (identifier))
+      (arguments
+        (argument
+          (scoped_identifier
+            (qualified_identifier
+              (identifier))
+            (identifier))))
+      (qualified_identifier
+        (identifier))
+      (arguments
+        (argument
+          (integer))))
+    name: (identifier)
+    (type_parameters
+      (type_parameter
+        name: (identifier)
+        constraint_type: (type_specifier
+          (qualified_identifier
+            (identifier))))
+      (type_parameter
+        name: (identifier)
+        constraint_type: (type_specifier
+          (qualified_identifier
+            (identifier))
+          (type_arguments
+            (type_specifier
+              (qualified_identifier
+                (identifier)))
+            (type_specifier
+              (qualified_identifier
+                (identifier)))))))
+    (extends_clause
+      (type_specifier
+        (qualified_identifier
+          (identifier)))
+      (type_specifier
+        (qualified_identifier
+          (identifier)
+          (identifier))
+        (type_arguments
+          (type_specifier
+            (qualified_identifier
+              (identifier)))
+          (type_specifier
+            (qualified_identifier
+              (identifier)))))
+      (type_specifier
+        (qualified_identifier
+          (identifier)
+          (identifier))))
+    body: (member_declarations
+      (method_declaration
+        name: (identifier)
+        (type_parameters
+          (type_parameter
+            name: (identifier)
+            constraint_type: (type_specifier
+              (qualified_identifier
+                (identifier))))
+          (type_parameter
+            name: (identifier)
+            constraint_type: (type_specifier
+              (qualified_identifier
+                (identifier)))))
+        (parameters)
+        return_type: (type_specifier
+          (qualified_identifier
+            (identifier)))
+        body: (compound_statement)))))
+
+==========================
+Interface where
+==========================
+
+interface C <T1> extends B<T2> where T1 as T2 {}
+
+---
+
+(script
+  (interface_declaration
+    name: (identifier)
+    (type_parameters
+      (type_parameter
+        name: (identifier)))
+    (extends_clause
+      (type_specifier
+        (qualified_identifier
+          (identifier))
+        (type_arguments
+          (type_specifier
+            (qualified_identifier
+              (identifier))))))
+    (where_clause
+      (where_constraint
+        constraint_left_type: (type_specifier
+          (qualified_identifier
+            (identifier)))
+        constraint_right_type: (type_specifier
+          (qualified_identifier
+            (identifier)))))
+    body: (member_declarations)))
+
+==========================
+Like type modifier
+==========================
+
+function func<Ta as ~int>(~?(function(int): bool) $func): ~int {}
+
+---
+
+(script
+  (function_declaration
+    name: (identifier)
+    (type_parameters
+      (type_parameter
+        name: (identifier)
+        constraint_type: (type_specifier
+          (like_modifier))))
+    (parameters
+      (parameter
+        type: (function_type_specifier
+          (like_modifier)
+          (nullable_modifier)
+          (type_specifier)
+          return_type: (type_specifier))
+        name: (variable)))
+    return_type: (type_specifier
+      (like_modifier))
+    body: (compound_statement)))
+
+==========================
+Method
+==========================
+
+abstract class C {
+  static function method1(): void {}
+  public function method2(): void {}
+  function method3(): void {}
+  abstract public static function method4();
+  final public static function method5(): void {}
+}
+
+---
+
+(script
+  (class_declaration
+    (abstract_modifier)
+    name: (identifier)
+    body: (member_declarations
+      (method_declaration
+        (static_modifier)
+        name: (identifier)
+        (parameters)
+        return_type: (type_specifier)
+        body: (compound_statement))
+      (method_declaration
+        (visibility_modifier)
+        name: (identifier)
+        (parameters)
+        return_type: (type_specifier)
+        body: (compound_statement))
+      (method_declaration
+        name: (identifier)
+        (parameters)
+        return_type: (type_specifier)
+        body: (compound_statement))
+      (method_declaration
+        (abstract_modifier)
+        (visibility_modifier)
+        (static_modifier)
+        name: (identifier)
+        (parameters))
+      (method_declaration
+        (final_modifier)
+        (visibility_modifier)
+        (static_modifier)
+        name: (identifier)
+        (parameters)
+        return_type: (type_specifier)
+        body: (compound_statement)))))
+
+==========================
+Namespace brace
+==========================
+
+namespace Space {
+}
+
+---
+
+(script
+  (namespace_declaration
+    name: (qualified_identifier
+      (identifier))
+    body: (compound_statement)))
+
+==========================
+Namespace semicolon
+==========================
+
+namespace Space;
+
+---
+
+(script
+  (namespace_declaration
+    name: (qualified_identifier
+      (identifier))))
+
+==========================
+Namespace without name
+==========================
+
+namespace {
+}
+
+---
+
+(script
+  (namespace_declaration
+    body: (compound_statement)))
+
+==========================
+Newtype alias
+==========================
+
+newtype I = int;
+
+newtype I as int = arrakey;
+
+---
+
+(script
+  (alias_declaration
+    (identifier)
+    (type_specifier))
+  (alias_declaration
+    (identifier)
+    as: (type_specifier)
+    (type_specifier
+      (qualified_identifier
+        (identifier)))))
+
+==========================
+Property
+==========================
+
+<<__ConsistentConstruct>>
+class C {
+  static $var1 = 1;
+  public $var2 = 1;
+  static public $var3 = 1;
+  public static $var4 = 1;
+
+  public $var5;
+  public static $var6;
+
+  public int $var7;
+  <<__LateInit>>
+  public static int $var8;
+}
+
+---
+
+(script
+  (class_declaration
+    (attribute_modifier
+      (qualified_identifier
+        (identifier)))
+    name: (identifier)
+    body: (member_declarations
+      (property_declaration
+        (static_modifier)
+        (property_declarator
+          name: (variable)
+          value: (integer)))
+      (property_declaration
+        (visibility_modifier)
+        (property_declarator
+          name: (variable)
+          value: (integer)))
+      (property_declaration
+        (static_modifier)
+        (visibility_modifier)
+        (property_declarator
+          name: (variable)
+          value: (integer)))
+      (property_declaration
+        (visibility_modifier)
+        (static_modifier)
+        (property_declarator
+          name: (variable)
+          value: (integer)))
+      (property_declaration
+        (visibility_modifier)
+        (property_declarator
+          name: (variable)))
+      (property_declaration
+        (visibility_modifier)
+        (static_modifier)
+        (property_declarator
+          name: (variable)))
+      (property_declaration
+        (visibility_modifier)
+        type: (type_specifier)
+        (property_declarator
+          name: (variable)))
+      (property_declaration
+        (attribute_modifier
+          (qualified_identifier
+            (identifier)))
+        (visibility_modifier)
+        (static_modifier)
+        type: (type_specifier)
+        (property_declarator
+          name: (variable))))))
+
+==========================
+Qualified namespace brace
+==========================
+
+namespace Name\Space {
+}
+
+---
+
+(script
+  (namespace_declaration
+    name: (qualified_identifier
+      (identifier)
+      (identifier))
+    body: (compound_statement)))
+
+==========================
+Qualified namespace semicolon
+==========================
+
+namespace Name\Space;
+
+---
+
+(script
+  (namespace_declaration
+    name: (qualified_identifier
+      (identifier)
+      (identifier))))
+
+==========================
+Reify
+==========================
+
+class C<reify T> {}
+
+function func<reify T>(): void {}
+
+---
+
+(script
+  (class_declaration
+    name: (identifier)
+    (type_parameters
+      (type_parameter
+        (reify_modifier)
+        name: (identifier)))
+    body: (member_declarations))
+  (function_declaration
+    name: (identifier)
+    (type_parameters
+      (type_parameter
+        (reify_modifier)
+        name: (identifier)))
+    (parameters)
+    return_type: (type_specifier)
+    body: (compound_statement)))
+
+==========================
+Repeating type parameter constraint
+==========================
+
+function func<Ta as Tb as int>(): void {}
+
+---
+
+(script
+  (function_declaration
+    name: (identifier)
+    (type_parameters
+      (type_parameter
+        name: (identifier)
+        constraint_type: (type_specifier
+          (qualified_identifier
+            (identifier)))
+        constraint_type: (type_specifier)))
+    (parameters)
+    return_type: (type_specifier)
+    body: (compound_statement)))
+
+==========================
+Require implements and extends
+==========================
+
+trait T<T> {
+  require implements I<T>;
+  require extends C<T>;
+}
+
+---
+
+(script
+  (trait_declaration
+    name: (identifier)
+    (type_parameters
+      (type_parameter
+        name: (identifier)))
+    body: (member_declarations
+      (require_implements_clause
+        (type_specifier
+          (qualified_identifier
+            (identifier))
+          (type_arguments
+            (type_specifier
+              (qualified_identifier
+                (identifier))))))
+      (require_extends_clause
+        (type_specifier
+          (qualified_identifier
+            (identifier))
+          (type_arguments
+            (type_specifier
+              (qualified_identifier
+                (identifier)))))))))
+
+==========================
+Shape type specifier
+==========================
+
+type circle = shape(
+  ?'int' => int,
+  'shape' => shape(
+    'int' => ?int,
+    ...
+  ),
+  ...
+);
+
+type nothing = shape();
+
+---
+
+(script
+  (alias_declaration
+    (identifier)
+    (shape_type_specifier
+      (field_specifier
+        (optional_modifier)
+        (string)
+        (type_specifier))
+      (field_specifier
+        (string)
+        (shape_type_specifier
+          (field_specifier
+            (string)
+            (type_specifier
+              (nullable_modifier)))
+          (open_modifier)))
+      (open_modifier)))
+  (alias_declaration
+    (identifier)
+    (shape_type_specifier)))
+
+==========================
+Trait
+==========================
+
+<<Attribute(R::class), Attribute(1,),>>
+trait F<Ta as A, Tb super B<A, C>> implements A\B<A, C>, C\D {
+  function method<Ta as A, Tb super B>(): Tc {}
+}
+
+
+---
+
+(script
+  (trait_declaration
+    (attribute_modifier
+      (qualified_identifier
+        (identifier))
+      (arguments
+        (argument
+          (scoped_identifier
+            (qualified_identifier
+              (identifier))
+            (identifier))))
+      (qualified_identifier
+        (identifier))
+      (arguments
+        (argument
+          (integer))))
+    name: (identifier)
+    (type_parameters
+      (type_parameter
+        name: (identifier)
+        constraint_type: (type_specifier
+          (qualified_identifier
+            (identifier))))
+      (type_parameter
+        name: (identifier)
+        constraint_type: (type_specifier
+          (qualified_identifier
+            (identifier))
+          (type_arguments
+            (type_specifier
+              (qualified_identifier
+                (identifier)))
+            (type_specifier
+              (qualified_identifier
+                (identifier)))))))
+    (implements_clause
+      (type_specifier
+        (qualified_identifier
+          (identifier)
+          (identifier))
+        (type_arguments
+          (type_specifier
+            (qualified_identifier
+              (identifier)))
+          (type_specifier
+            (qualified_identifier
+              (identifier)))))
+      (type_specifier
+        (qualified_identifier
+          (identifier)
+          (identifier))))
+    body: (member_declarations
+      (method_declaration
+        name: (identifier)
+        (type_parameters
+          (type_parameter
+            name: (identifier)
+            constraint_type: (type_specifier
+              (qualified_identifier
+                (identifier))))
+          (type_parameter
+            name: (identifier)
+            constraint_type: (type_specifier
+              (qualified_identifier
+                (identifier)))))
+        (parameters)
+        return_type: (type_specifier
+          (qualified_identifier
+            (identifier)))
+        body: (compound_statement)))))
+
+==========================
+Trait where
+==========================
+
+trait C <T1> implements A<T3> where T1 super T3 {}
+
+---
+
+(script
+  (trait_declaration
+    name: (identifier)
+    (type_parameters
+      (type_parameter
+        name: (identifier)))
+    (implements_clause
+      (type_specifier
+        (qualified_identifier
+          (identifier))
+        (type_arguments
+          (type_specifier
+            (qualified_identifier
+              (identifier))))))
+    (where_clause
+      (where_constraint
+        constraint_left_type: (type_specifier
+          (qualified_identifier
+            (identifier)))
+        constraint_right_type: (type_specifier
+          (qualified_identifier
+            (identifier)))))
+    body: (member_declarations)))
+
+==========================
+Tuple type
+==========================
+
+function func((dict<int, mixed>, int) $arg): ?(int, C, B\A) {}
+
+---
+
+(script
+  (function_declaration
+    name: (identifier)
+    (parameters
+      (parameter
+        type: (tuple_type_specifier
+          (type_specifier
+            (type_arguments
+              (type_specifier)
+              (type_specifier)))
+          (type_specifier))
+        name: (variable)))
+    return_type: (tuple_type_specifier
+      (nullable_modifier)
+      (type_specifier)
+      (type_specifier
+        (qualified_identifier
+          (identifier)))
+      (type_specifier
+        (qualified_identifier
+          (identifier)
+          (identifier))))
+    body: (compound_statement)))
+
+==========================
+Type alias
+==========================
+
+type I = int;
+
+---
+
+(script
+  (alias_declaration
+    (identifier)
+    (type_specifier)))
+
+==========================
+Type alias type parameters
+==========================
+
+type I1<T as R super H> = I2<T>;
+
+# Only newtype can have a type constraint.
+newtype I2<T as R super H> as N<B> = I1<T>;
+
+---
+
+(script
+  (alias_declaration
+    (identifier)
+    (type_parameters
+      (type_parameter
+        name: (identifier)
+        constraint_type: (type_specifier
+          (qualified_identifier
+            (identifier)))
+        constraint_type: (type_specifier
+          (qualified_identifier
+            (identifier)))))
+    (type_specifier
+      (qualified_identifier
+        (identifier))
+      (type_arguments
+        (type_specifier
+          (qualified_identifier
+            (identifier))))))
+  (comment)
+  (alias_declaration
+    (identifier)
+    (type_parameters
+      (type_parameter
+        name: (identifier)
+        constraint_type: (type_specifier
+          (qualified_identifier
+            (identifier)))
+        constraint_type: (type_specifier
+          (qualified_identifier
+            (identifier)))))
+    as: (type_specifier
+      (qualified_identifier
+        (identifier))
+      (type_arguments
+        (type_specifier
+          (qualified_identifier
+            (identifier)))))
+    (type_specifier
+      (qualified_identifier
+        (identifier))
+      (type_arguments
+        (type_specifier
+          (qualified_identifier
+            (identifier)))))))
+
+==========================
+Type const
+==========================
+
+class C {
+  const type T1;
+  const type T2 = int;
+  <<A3(1), A2(2,3,)>>
+  const type T3 as int;
+  const type T4<<<Attr>> T3> as int = arraykey;
+  abstract const type T5 as ?int = ?arraykey;
+}
+
+---
+
+(script
+  (class_declaration
+    name: (identifier)
+    body: (member_declarations
+      (type_const_declaration
+        name: (identifier))
+      (type_const_declaration
+        name: (identifier)
+        type: (type_specifier))
+      (type_const_declaration
+        (attribute_modifier
+          (qualified_identifier
+            (identifier))
+          (arguments
+            (argument
+              (integer)))
+          (qualified_identifier
+            (identifier))
+          (arguments
+            (argument
+              (integer))
+            (argument
+              (integer))))
+        name: (identifier)
+        as: (type_specifier))
+      (type_const_declaration
+        name: (identifier)
+        (type_parameters
+          (type_parameter
+            (attribute_modifier
+              (qualified_identifier
+                (identifier)))
+            name: (identifier)))
+        as: (type_specifier)
+        type: (type_specifier))
+      (type_const_declaration
+        (abstract_modifier)
+        name: (identifier)
+        as: (type_specifier
+          (nullable_modifier))
+        type: (type_specifier
+          (nullable_modifier))))))
+
+==========================
+Use trait
+==========================
+
+class C {
+  use A;
+
+  use B<int>;
+
+  use C, D { D as E; }
+
+  use F, G<vec<int>>, H {
+    H::methodG insteadof G;
+    G::methodH insteadof H;
+  }
+}
+
+---
+
+(script
+  (class_declaration
+    name: (identifier)
+    body: (member_declarations
+      (trait_use_clause
+        (type_specifier
+          (qualified_identifier
+            (identifier))))
+      (trait_use_clause
+        (type_specifier
+          (qualified_identifier
+            (identifier))
+          (type_arguments
+            (type_specifier))))
+      (trait_use_clause
+        (type_specifier
+          (qualified_identifier
+            (identifier)))
+        (type_specifier
+          (qualified_identifier
+            (identifier)))
+        (trait_alias_clause
+          (identifier)
+          (identifier)))
+      (trait_use_clause
+        (type_specifier
+          (qualified_identifier
+            (identifier)))
+        (type_specifier
+          (qualified_identifier
+            (identifier))
+          (type_arguments
+            (type_specifier
+              (type_arguments
+                (type_specifier)))))
+        (type_specifier
+          (qualified_identifier
+            (identifier)))
+        (trait_select_clause
+          (qualified_identifier
+            (identifier))
+          (identifier)
+          (qualified_identifier
+            (identifier)))
+        (trait_select_clause
+          (qualified_identifier
+            (identifier))
+          (identifier)
+          (qualified_identifier
+            (identifier)))))))
+
+==========================
+Xhp class attribute
+==========================
+
+class :a {
+    attribute int extra_attr;
+    // XHP identifiers are optional for this case of attribute transfer.
+    attribute :XHP:HTML:div;
+}
+
+// DEPRECATED:
+// Before XHP namespace support (in XHP-Lib v3),
+// a special category keyword could be used instead of an interface.
+// Note: An XHP class cannot have multiple category or children declarations.
+class :a {
+    category %foo:bar;
+}
+class :a {
+    category %name1, %name2;
+}
+
+// Also, a special children keyword with a regex-like syntax could be used.
+// See https://github.com/hhvm/xhp-lib/blob/v3.x/tests/ChildRuleTest.php
+class :a {
+    children (:div);
+}
+class :a {
+    children any;
+}
+class :a {
+    children (:bar*, :baz?, pcdata);
+}
+class :a {
+    children (:div*);
+}
+class :a {
+    children (:div+);
+}
+class :a {
+    children (:div, :div);
+}
+class :a {
+    children (:div | :code);
+}
+class :a {
+    children (:div | (:code+));
+}
+class :a {
+    children (:div | :code | :p);
+}
+class :a {
+    children (%flow);
+}
+
+---
+
+(script
+  (class_declaration
+    name: (xhp_class_identifier)
+    body: (member_declarations
+      (xhp_attribute_declaration
+        (xhp_class_attribute
+          type: (type_specifier)
+          name: (xhp_identifier)))
+      (comment)
+      (xhp_attribute_declaration
+        (xhp_class_attribute
+          type: (type_specifier
+            (xhp_class_identifier))))))
+  (comment)
+  (comment)
+  (comment)
+  (comment)
+  (class_declaration
+    name: (xhp_class_identifier)
+    body: (member_declarations
+      (xhp_category_declaration
+        (xhp_category_identifier))))
+  (class_declaration
+    name: (xhp_class_identifier)
+    body: (member_declarations
+      (xhp_category_declaration
+        (xhp_category_identifier)
+        (xhp_category_identifier))))
+  (comment)
+  (comment)
+  (class_declaration
+    name: (xhp_class_identifier)
+    body: (member_declarations
+      (xhp_children_declaration
+        (parenthesized_expression
+          (xhp_class_identifier)))))
+  (class_declaration
+    name: (xhp_class_identifier)
+    body: (member_declarations
+      (xhp_children_declaration
+        (xhp_identifier))))
+  (class_declaration
+    name: (xhp_class_identifier)
+    body: (member_declarations
+      (xhp_children_declaration
+        (parenthesized_expression
+          (postfix_unary_expression
+            (xhp_class_identifier))
+          (postfix_unary_expression
+            (xhp_class_identifier))
+          (xhp_identifier)))))
+  (class_declaration
+    name: (xhp_class_identifier)
+    body: (member_declarations
+      (xhp_children_declaration
+        (parenthesized_expression
+          (postfix_unary_expression
+            (xhp_class_identifier))))))
+  (class_declaration
+    name: (xhp_class_identifier)
+    body: (member_declarations
+      (xhp_children_declaration
+        (parenthesized_expression
+          (postfix_unary_expression
+            (xhp_class_identifier))))))
+  (class_declaration
+    name: (xhp_class_identifier)
+    body: (member_declarations
+      (xhp_children_declaration
+        (parenthesized_expression
+          (xhp_class_identifier)
+          (xhp_class_identifier)))))
+  (class_declaration
+    name: (xhp_class_identifier)
+    body: (member_declarations
+      (xhp_children_declaration
+        (parenthesized_expression
+          (binary_expression
+            (xhp_class_identifier)
+            (xhp_class_identifier))))))
+  (class_declaration
+    name: (xhp_class_identifier)
+    body: (member_declarations
+      (xhp_children_declaration
+        (parenthesized_expression
+          (binary_expression
+            (xhp_class_identifier)
+            (parenthesized_expression
+              (postfix_unary_expression
+                (xhp_class_identifier))))))))
+  (class_declaration
+    name: (xhp_class_identifier)
+    body: (member_declarations
+      (xhp_children_declaration
+        (parenthesized_expression
+          (binary_expression
+            (binary_expression
+              (xhp_class_identifier)
+              (xhp_class_identifier))
+            (xhp_class_identifier))))))
+  (class_declaration
+    name: (xhp_class_identifier)
+    body: (member_declarations
+      (xhp_children_declaration
+        (parenthesized_expression
+          (xhp_category_identifier))))))

--- a/test/corpus/declarations.txt
+++ b/test/corpus/declarations.txt
@@ -2,8 +2,6 @@
 Async functions
 ==========================
 
-async function func0(): void {}
-
 async function func1<T1 as int>() {}
 
 async ($x) ==> $x + 1;

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -1,0 +1,2705 @@
+==========================
+Anonymous function
+==========================
+
+$f1 = function($p1) {};
+
+$f2 = function($p1, $p2): int {};
+
+---
+
+(script
+  (expression_statement
+    (binary_expression
+      left: (variable)
+      right: (anonymous_function_expression
+        (parameters
+          (parameter
+            name: (variable)))
+        body: (compound_statement))))
+  (expression_statement
+    (binary_expression
+      left: (variable)
+      right: (anonymous_function_expression
+        (parameters
+          (parameter
+            name: (variable))
+          (parameter
+            name: (variable)))
+        return_type: (type_specifier)
+        body: (compound_statement)))))
+
+==========================
+Anonymous function type
+==========================
+
+function((function(int...): int) $function): ((function(int): int), (function(): void)) use ($function)  {};
+
+---
+
+(script
+  (expression_statement
+    (anonymous_function_expression
+      (parameters
+        (parameter
+          type: (function_type_specifier
+            (type_specifier)
+            (variadic_modifier)
+            return_type: (type_specifier))
+          name: (variable)))
+      return_type: (tuple_type_specifier
+        (function_type_specifier
+          (type_specifier)
+          return_type: (type_specifier))
+        (function_type_specifier
+          return_type: (type_specifier)))
+      (use_clause
+        (variable))
+      body: (compound_statement))))
+
+==========================
+Anonymous function use
+==========================
+
+$f3 = function($p1) use ($p2,) {};
+
+$f4 = function($p1): int use ($p2, $p3) {};
+
+---
+
+(script
+  (expression_statement
+    (binary_expression
+      left: (variable)
+      right: (anonymous_function_expression
+        (parameters
+          (parameter
+            name: (variable)))
+        (use_clause
+          (variable))
+        body: (compound_statement))))
+  (expression_statement
+    (binary_expression
+      left: (variable)
+      right: (anonymous_function_expression
+        (parameters
+          (parameter
+            name: (variable)))
+        return_type: (type_specifier)
+        (use_clause
+          (variable)
+          (variable))
+        body: (compound_statement)))))
+
+==========================
+As
+==========================
+
+$var as int;
+$var ?as int;
+
+---
+
+(script
+  (expression_statement
+    (as_expression
+      left: (variable)
+      right: (type_specifier)))
+  (expression_statement
+    (as_expression
+      left: (variable)
+      right: (type_specifier))))
+
+==========================
+Assignment
+==========================
+
+$var = 1;
+$var[] = 1;
+$var[1] = 1;
+$var['key'] = 1;
+$var[$var['key']] = 1;
+$var[$var['key']][] = 1;
+$var[][$var['key']] = 1;
+
+list($var, $bar) = tuple(1, 1);
+list($var[], $bar) = tuple(1, 1);
+list($var[1], $bar[]) = tuple(1, 1);
+list($var['key'], $bar[1]) = tuple(1, 1);
+list($var[$var['key']], $bar['key']) = tuple(1, 1);
+list($var[$var['key']][], $var[$var['key']],) = tuple(1, 1);
+
+---
+
+(script
+  (expression_statement
+    (binary_expression
+      left: (variable)
+      right: (integer)))
+  (expression_statement
+    (binary_expression
+      left: (subscript_expression
+        (variable))
+      right: (integer)))
+  (expression_statement
+    (binary_expression
+      left: (subscript_expression
+        (variable)
+        (integer))
+      right: (integer)))
+  (expression_statement
+    (binary_expression
+      left: (subscript_expression
+        (variable)
+        (string))
+      right: (integer)))
+  (expression_statement
+    (binary_expression
+      left: (subscript_expression
+        (variable)
+        (subscript_expression
+          (variable)
+          (string)))
+      right: (integer)))
+  (expression_statement
+    (binary_expression
+      left: (subscript_expression
+        (subscript_expression
+          (variable)
+          (subscript_expression
+            (variable)
+            (string))))
+      right: (integer)))
+  (expression_statement
+    (binary_expression
+      left: (subscript_expression
+        (subscript_expression
+          (variable))
+        (subscript_expression
+          (variable)
+          (string)))
+      right: (integer)))
+  (expression_statement
+    (binary_expression
+      left: (list_expression
+        (variable)
+        (variable))
+      right: (tuple
+        (integer)
+        (integer))))
+  (expression_statement
+    (binary_expression
+      left: (list_expression
+        (subscript_expression
+          (variable))
+        (variable))
+      right: (tuple
+        (integer)
+        (integer))))
+  (expression_statement
+    (binary_expression
+      left: (list_expression
+        (subscript_expression
+          (variable)
+          (integer))
+        (subscript_expression
+          (variable)))
+      right: (tuple
+        (integer)
+        (integer))))
+  (expression_statement
+    (binary_expression
+      left: (list_expression
+        (subscript_expression
+          (variable)
+          (string))
+        (subscript_expression
+          (variable)
+          (integer)))
+      right: (tuple
+        (integer)
+        (integer))))
+  (expression_statement
+    (binary_expression
+      left: (list_expression
+        (subscript_expression
+          (variable)
+          (subscript_expression
+            (variable)
+            (string)))
+        (subscript_expression
+          (variable)
+          (string)))
+      right: (tuple
+        (integer)
+        (integer))))
+  (expression_statement
+    (binary_expression
+      left: (list_expression
+        (subscript_expression
+          (subscript_expression
+            (variable)
+            (subscript_expression
+              (variable)
+              (string))))
+        (subscript_expression
+          (variable)
+          (subscript_expression
+            (variable)
+            (string))))
+      right: (tuple
+        (integer)
+        (integer)))))
+
+==========================
+Async
+==========================
+
+async {
+};
+
+async {
+  concurrent {
+    await func1();
+    await func2();
+  }
+};
+
+---
+
+(script
+  (expression_statement
+    (awaitable_expression
+      (compound_statement)))
+  (expression_statement
+    (awaitable_expression
+      (compound_statement
+        (concurrent_statement
+          (compound_statement
+            (expression_statement
+              (prefix_unary_expression
+                operand: (call_expression
+                  function: (qualified_identifier
+                    (identifier))
+                  (arguments))))
+            (expression_statement
+              (prefix_unary_expression
+                operand: (call_expression
+                  function: (qualified_identifier
+                    (identifier))
+                  (arguments))))))))))
+
+==========================
+Augmented assignment
+==========================
+
+$var ??= 1;
+$var[] .= 'stringgg';
+$var[1] |= 1;
+$var['key'] ^= 1;
+$var[$var['key']] &= 1;
+$var[$var['key']][] <<= 1;
+$var[][$var['key']] >>= 1;
+
+list($var, $bar) += tuple(1, 1);
+list($var[], $bar) -= tuple(1, 1);
+list($var[1], $bar[]) *= tuple(1, 1);
+list($var['key'], $bar[1]) /= tuple(1, 1);
+list($var[$var['key']], $bar['key']) %= tuple(1, 1);
+list($var[$var['key']][], $var[$var['key']],) **= tuple(1, 1);
+
+---
+
+(script
+  (expression_statement
+    (binary_expression
+      left: (variable)
+      right: (integer)))
+  (expression_statement
+    (binary_expression
+      left: (subscript_expression
+        (variable))
+      right: (string)))
+  (expression_statement
+    (binary_expression
+      left: (subscript_expression
+        (variable)
+        (integer))
+      right: (integer)))
+  (expression_statement
+    (binary_expression
+      left: (subscript_expression
+        (variable)
+        (string))
+      right: (integer)))
+  (expression_statement
+    (binary_expression
+      left: (subscript_expression
+        (variable)
+        (subscript_expression
+          (variable)
+          (string)))
+      right: (integer)))
+  (expression_statement
+    (binary_expression
+      left: (subscript_expression
+        (subscript_expression
+          (variable)
+          (subscript_expression
+            (variable)
+            (string))))
+      right: (integer)))
+  (expression_statement
+    (binary_expression
+      left: (subscript_expression
+        (subscript_expression
+          (variable))
+        (subscript_expression
+          (variable)
+          (string)))
+      right: (integer)))
+  (expression_statement
+    (binary_expression
+      left: (list_expression
+        (variable)
+        (variable))
+      right: (tuple
+        (integer)
+        (integer))))
+  (expression_statement
+    (binary_expression
+      left: (list_expression
+        (subscript_expression
+          (variable))
+        (variable))
+      right: (tuple
+        (integer)
+        (integer))))
+  (expression_statement
+    (binary_expression
+      left: (list_expression
+        (subscript_expression
+          (variable)
+          (integer))
+        (subscript_expression
+          (variable)))
+      right: (tuple
+        (integer)
+        (integer))))
+  (expression_statement
+    (binary_expression
+      left: (list_expression
+        (subscript_expression
+          (variable)
+          (string))
+        (subscript_expression
+          (variable)
+          (integer)))
+      right: (tuple
+        (integer)
+        (integer))))
+  (expression_statement
+    (binary_expression
+      left: (list_expression
+        (subscript_expression
+          (variable)
+          (subscript_expression
+            (variable)
+            (string)))
+        (subscript_expression
+          (variable)
+          (string)))
+      right: (tuple
+        (integer)
+        (integer))))
+  (expression_statement
+    (binary_expression
+      left: (list_expression
+        (subscript_expression
+          (subscript_expression
+            (variable)
+            (subscript_expression
+              (variable)
+              (string))))
+        (subscript_expression
+          (variable)
+          (subscript_expression
+            (variable)
+            (string))))
+      right: (tuple
+        (integer)
+        (integer)))))
+
+==========================
+Await
+==========================
+
+function func(): void {
+  await 'await';
+}
+
+---
+
+(script
+  (function_declaration
+    name: (identifier)
+    (parameters)
+    return_type: (type_specifier)
+    body: (compound_statement
+      (expression_statement
+        (prefix_unary_expression
+          operand: (string))))))
+
+==========================
+Binary
+==========================
+
+1 ?? 1;
+1 || 1;
+1 && 1;
+1 | 1;
+1 ^ 1;
+1 & 1;
+1 == 1;
+1 != 1;
+1 === 1;
+1 !== 1;
+1 < 1;
+1 > 1;
+1 <= 1;
+1 >= 1;
+1 <=> 1;
+1 << 1;
+1 >> 1;
+1 + 1;
+1 - 1;
+1 . 1;
+1 * 1;
+1 / 1;
+1 % 1;
+1 ** 1;
+
+---
+
+(script
+  (expression_statement
+    (binary_expression
+      left: (integer)
+      right: (integer)))
+  (expression_statement
+    (binary_expression
+      left: (integer)
+      right: (integer)))
+  (expression_statement
+    (binary_expression
+      left: (integer)
+      right: (integer)))
+  (expression_statement
+    (binary_expression
+      left: (integer)
+      right: (integer)))
+  (expression_statement
+    (binary_expression
+      left: (integer)
+      right: (integer)))
+  (expression_statement
+    (binary_expression
+      left: (integer)
+      right: (integer)))
+  (expression_statement
+    (binary_expression
+      left: (integer)
+      right: (integer)))
+  (expression_statement
+    (binary_expression
+      left: (integer)
+      right: (integer)))
+  (expression_statement
+    (binary_expression
+      left: (integer)
+      right: (integer)))
+  (expression_statement
+    (binary_expression
+      left: (integer)
+      right: (integer)))
+  (expression_statement
+    (binary_expression
+      left: (integer)
+      right: (integer)))
+  (expression_statement
+    (binary_expression
+      left: (integer)
+      right: (integer)))
+  (expression_statement
+    (binary_expression
+      left: (integer)
+      right: (integer)))
+  (expression_statement
+    (binary_expression
+      left: (integer)
+      right: (integer)))
+  (expression_statement
+    (binary_expression
+      left: (integer)
+      right: (integer)))
+  (expression_statement
+    (binary_expression
+      left: (integer)
+      right: (integer)))
+  (expression_statement
+    (binary_expression
+      left: (integer)
+      right: (integer)))
+  (expression_statement
+    (binary_expression
+      left: (integer)
+      right: (integer)))
+  (expression_statement
+    (binary_expression
+      left: (integer)
+      right: (integer)))
+  (expression_statement
+    (binary_expression
+      left: (integer)
+      right: (integer)))
+  (expression_statement
+    (binary_expression
+      left: (integer)
+      right: (integer)))
+  (expression_statement
+    (binary_expression
+      left: (integer)
+      right: (integer)))
+  (expression_statement
+    (binary_expression
+      left: (integer)
+      right: (integer)))
+  (expression_statement
+    (binary_expression
+      left: (integer)
+      right: (integer))))
+
+==========================
+Binary combined
+==========================
+
+1 ??
+1 ||
+1 &&
+1 |
+1 ^
+~ 1 &
+1 ==
+1 !=
+1 ===
+! 1 !==
+1 <
+1 >
+1 <=
+1 >=
+1 <=>
+1 <<
+1 >>
++ 1 +
+- 1 -
+1 .
+1 *
+1 /
+1 %
+1 ** 1;
+
+---
+
+(script
+  (expression_statement
+    (binary_expression
+      left: (integer)
+      right: (binary_expression
+        left: (binary_expression
+          left: (integer)
+          right: (binary_expression
+            left: (integer)
+            right: (integer)))
+        right: (binary_expression
+          left: (binary_expression
+            left: (integer)
+            right: (prefix_unary_expression
+              operand: (integer)))
+          right: (binary_expression
+            left: (binary_expression
+              left: (binary_expression
+                left: (binary_expression
+                  left: (integer)
+                  right: (integer))
+                right: (integer))
+              right: (prefix_unary_expression
+                operand: (integer)))
+            right: (binary_expression
+              left: (binary_expression
+                left: (binary_expression
+                  left: (binary_expression
+                    left: (binary_expression
+                      left: (integer)
+                      right: (integer))
+                    right: (integer))
+                  right: (integer))
+                right: (integer))
+              right: (binary_expression
+                left: (binary_expression
+                  left: (integer)
+                  right: (integer))
+                right: (binary_expression
+                  left: (binary_expression
+                    left: (binary_expression
+                      left: (prefix_unary_expression
+                        operand: (integer))
+                      right: (prefix_unary_expression
+                        operand: (integer)))
+                    right: (integer))
+                  right: (binary_expression
+                    left: (binary_expression
+                      left: (binary_expression
+                        left: (integer)
+                        right: (integer))
+                      right: (integer))
+                    right: (binary_expression
+                      left: (integer)
+                      right: (integer))))))))))))
+
+==========================
+Binary null as
+==========================
+
+$var['key'] ?? 1 as nonnull;
+
+$var['key'] ?? null as nonnull;
+
+---
+
+(script
+  (expression_statement
+    (binary_expression
+      left: (subscript_expression
+        (variable)
+        (string))
+      right: (as_expression
+        left: (integer)
+        right: (type_specifier))))
+  (expression_statement
+    (binary_expression
+      left: (subscript_expression
+        (variable)
+        (string))
+      right: (as_expression
+        left: (null)
+        right: (type_specifier)))))
+
+==========================
+Binary with strings
+==========================
+
+'??' ??
+'||' ||
+'&&' &&
+'|' |
+'^' ^
+'&' &
+'==' ==
+'!=' !=
+'===' ===
+'!==' !==
+'<' <
+'>' >
+'<=' <=
+'>=' >=
+'<=>' <=>
+'<<' <<
+'>>' >>
+'+' +
+'-' -
+'.' .
+'*' *
+'/' /
+'%' %
+'**' ** '??';
+
+---
+
+(script
+  (expression_statement
+    (binary_expression
+      left: (string)
+      right: (binary_expression
+        left: (binary_expression
+          left: (string)
+          right: (binary_expression
+            left: (string)
+            right: (string)))
+        right: (binary_expression
+          left: (binary_expression
+            left: (string)
+            right: (string))
+          right: (binary_expression
+            left: (binary_expression
+              left: (binary_expression
+                left: (binary_expression
+                  left: (string)
+                  right: (string))
+                right: (string))
+              right: (string))
+            right: (binary_expression
+              left: (binary_expression
+                left: (binary_expression
+                  left: (binary_expression
+                    left: (binary_expression
+                      left: (string)
+                      right: (string))
+                    right: (string))
+                  right: (string))
+                right: (string))
+              right: (binary_expression
+                left: (binary_expression
+                  left: (string)
+                  right: (string))
+                right: (binary_expression
+                  left: (binary_expression
+                    left: (binary_expression
+                      left: (string)
+                      right: (string))
+                    right: (string))
+                  right: (binary_expression
+                    left: (binary_expression
+                      left: (binary_expression
+                        left: (string)
+                        right: (string))
+                      right: (string))
+                    right: (binary_expression
+                      left: (string)
+                      right: (string))))))))))))
+
+==========================
+Cast
+==========================
+
+(int)'int';
+(float)'float';
+(string)'string';
+(array)'array';
+
+---
+
+(script
+  (expression_statement
+    (cast_expression
+      value: (string)))
+  (expression_statement
+    (cast_expression
+      value: (string)))
+  (expression_statement
+    (cast_expression
+      value: (string)))
+  (expression_statement
+    (cast_expression
+      value: (string))))
+
+==========================
+Clone
+==========================
+
+clone 'clone';
+
+---
+
+(script
+  (expression_statement
+    (prefix_unary_expression
+      operand: (string))))
+
+==========================
+Collection
+==========================
+
+Vector {};
+HH\Vector {1, 2, 3};
+
+\HH\Map {};
+Map {'foo' => 1};
+
+Set {};
+Set {'foo', 'bar'};
+
+---
+
+(script
+  (expression_statement
+    (collection
+      (qualified_identifier
+        (identifier))))
+  (expression_statement
+    (collection
+      (qualified_identifier
+        (identifier)
+        (identifier))
+      (integer)
+      (integer)
+      (integer)))
+  (expression_statement
+    (collection
+      (qualified_identifier
+        (identifier)
+        (identifier))))
+  (expression_statement
+    (collection
+      (qualified_identifier
+        (identifier))
+      (element_initializer
+        (string)
+        (integer))))
+  (expression_statement
+    (collection
+      (qualified_identifier
+        (identifier))))
+  (expression_statement
+    (collection
+      (qualified_identifier
+        (identifier))
+      (string)
+      (string))))
+
+==========================
+Comments
+==========================
+
+// a ? : / */ # + re""
+
+# a ? : / */ # + re""
+
+/* a ? : / */ 1 + 1; # + re""
+
+/* # \
+*\/ 1 + 1
+*/
+
+
+---
+
+(script
+  (comment)
+  (comment)
+  (comment)
+  (expression_statement
+    (binary_expression
+      left: (integer)
+      right: (integer)))
+  (comment)
+  (comment))
+
+==========================
+Darray
+==========================
+
+darray[];
+darray[false => null, 2 => 1];
+
+---
+
+(script
+  (expression_statement
+    (array
+      (array_type)))
+  (expression_statement
+    (array
+      (array_type)
+      (element_initializer
+        (false)
+        (null))
+      (element_initializer
+        (integer)
+        (integer)))))
+
+==========================
+Dict
+==========================
+
+dict[];
+dict[false => null, 2.3 => 1];
+
+---
+
+(script
+  (expression_statement
+    (array
+      (array_type)))
+  (expression_statement
+    (array
+      (array_type)
+      (element_initializer
+        (false)
+        (null))
+      (element_initializer
+        (float)
+        (integer)))))
+
+==========================
+Function call
+==========================
+
+func();
+
+func<int>(1, inout $arg, ...null);
+
+$arg[func()]();
+
+---
+
+(script
+  (expression_statement
+    (call_expression
+      function: (qualified_identifier
+        (identifier))
+      (arguments)))
+  (expression_statement
+    (call_expression
+      function: (qualified_identifier
+        (identifier))
+      (type_arguments
+        (type_specifier))
+      (arguments
+        (argument
+          (integer))
+        (argument
+          (inout_modifier)
+          (variable))
+        (argument
+          (variadic_modifier)
+          (null)))))
+  (expression_statement
+    (call_expression
+      function: (subscript_expression
+        (variable)
+        (call_expression
+          function: (qualified_identifier
+            (identifier))
+          (arguments)))
+      (arguments))))
+
+==========================
+Function call lambda
+==========================
+
+// (lambda (call (awaitable)))
+$var = $arg ==> async { return $arg; }(1, ...vec[1,2,3]);
+
+// (call (lambda))
+$var = async $arg ==> { return $arg; }(1, ...vec[1,2,3]);
+
+($arg ==> $arg)(func(), inout $arg);
+
+---
+
+(script
+  (comment)
+  (expression_statement
+    (binary_expression
+      left: (variable)
+      right: (lambda_expression
+        (parameters
+          (parameter
+            name: (variable)))
+        body: (call_expression
+          function: (awaitable_expression
+            (compound_statement
+              (return_statement
+                (variable))))
+          (arguments
+            (argument
+              (integer))
+            (argument
+              (variadic_modifier)
+              (array
+                (array_type)
+                (integer)
+                (integer)
+                (integer))))))))
+  (comment)
+  (expression_statement
+    (binary_expression
+      left: (variable)
+      right: (call_expression
+        function: (lambda_expression
+          (async_modifier)
+          (parameters
+            (parameter
+              name: (variable)))
+          body: (compound_statement
+            (return_statement
+              (variable))))
+        (arguments
+          (argument
+            (integer))
+          (argument
+            (variadic_modifier)
+            (array
+              (array_type)
+              (integer)
+              (integer)
+              (integer)))))))
+  (expression_statement
+    (call_expression
+      function: (parenthesized_expression
+        (lambda_expression
+          (parameters
+            (parameter
+              name: (variable)))
+          body: (variable)))
+      (arguments
+        (argument
+          (call_expression
+            function: (qualified_identifier
+              (identifier))
+            (arguments)))
+        (argument
+          (inout_modifier)
+          (variable))))))
+
+==========================
+Function call pipe
+==========================
+
+$$();
+
+func() |> $$($$);
+
+---
+
+(script
+  (expression_statement
+    (call_expression
+      function: (pipe_variable)
+      (arguments)))
+  (expression_statement
+    (binary_expression
+      left: (call_expression
+        function: (qualified_identifier
+          (identifier))
+        (arguments))
+      right: (call_expression
+        function: (pipe_variable)
+        (arguments
+          (argument
+            (pipe_variable)))))))
+
+==========================
+Function call scoped
+==========================
+
+arg::$arg();
+
+arg::arg();
+
+---
+
+(script
+  (expression_statement
+    (call_expression
+      function: (scoped_identifier
+        (qualified_identifier
+          (identifier))
+        (variable))
+      (arguments)))
+  (expression_statement
+    (call_expression
+      function: (scoped_identifier
+        (qualified_identifier
+          (identifier))
+        (identifier))
+      (arguments))))
+
+==========================
+Function call selection
+==========================
+
+$arg?->$arg();
+
+arg->arg();
+
+---
+
+(script
+  (expression_statement
+    (call_expression
+      function: (selection_expression
+        (variable)
+        (variable))
+      (arguments)))
+  (expression_statement
+    (call_expression
+      function: (selection_expression
+        (qualified_identifier
+          (identifier))
+        (qualified_identifier
+          (identifier)))
+      (arguments))))
+
+==========================
+Include
+==========================
+
+include_once(__DIR__.'/../vendor/autoload.hack');
+include(__DIR__.'/../vendor/autoload.hack');
+
+---
+
+(script
+  (expression_statement
+    (include_expression
+      (parenthesized_expression
+        (binary_expression
+          left: (qualified_identifier
+            (identifier))
+          right: (string)))))
+  (expression_statement
+    (include_expression
+      (parenthesized_expression
+        (binary_expression
+          left: (qualified_identifier
+            (identifier))
+          right: (string))))))
+
+==========================
+Is
+==========================
+
+$var is int;
+
+---
+
+(script
+  (expression_statement
+    (is_expression
+      left: (variable)
+      right: (type_specifier))))
+
+==========================
+Keyset
+==========================
+
+keyset[];
+keyset[1, null, .1, true];
+
+---
+
+(script
+  (expression_statement
+    (array
+      (array_type)))
+  (expression_statement
+    (array
+      (array_type)
+      (integer)
+      (null)
+      (float)
+      (true))))
+
+==========================
+Lambda
+==========================
+
+(int $x): int ==> $x + 1;
+(int $x) ==> $x + 1;
+($x) ==> $x + 1;
+$x ==> $x + 1;
+
+---
+
+(script
+  (expression_statement
+    (lambda_expression
+      (parameters
+        (parameter
+          type: (type_specifier)
+          name: (variable)))
+      return_type: (type_specifier)
+      body: (binary_expression
+        left: (variable)
+        right: (integer))))
+  (expression_statement
+    (lambda_expression
+      (parameters
+        (parameter
+          type: (type_specifier)
+          name: (variable)))
+      body: (binary_expression
+        left: (variable)
+        right: (integer))))
+  (expression_statement
+    (lambda_expression
+      (parameters
+        (parameter
+          name: (variable)))
+      body: (binary_expression
+        left: (variable)
+        right: (integer))))
+  (expression_statement
+    (lambda_expression
+      (parameters
+        (parameter
+          name: (variable)))
+      body: (binary_expression
+        left: (variable)
+        right: (integer)))))
+
+==========================
+Lambda attribute
+==========================
+
+# HHVM requires parens to parse correctly 🤔 Tree-sitter doesn't.
+(<<A3(1), A2(2,3,)>>(int $x): int ==> $x + 1);
+
+(<<Attr, Bttr(1)>> $x ==> {});
+
+---
+
+(script
+  (comment)
+  (expression_statement
+    (parenthesized_expression
+      (lambda_expression
+        (attribute_modifier
+          (qualified_identifier
+            (identifier))
+          (arguments
+            (argument
+              (integer)))
+          (qualified_identifier
+            (identifier))
+          (arguments
+            (argument
+              (integer))
+            (argument
+              (integer))))
+        (parameters
+          (parameter
+            type: (type_specifier)
+            name: (variable)))
+        return_type: (type_specifier)
+        body: (binary_expression
+          left: (variable)
+          right: (integer)))))
+  (expression_statement
+    (parenthesized_expression
+      (lambda_expression
+        (attribute_modifier
+          (qualified_identifier
+            (identifier))
+          (qualified_identifier
+            (identifier))
+          (arguments
+            (argument
+              (integer))))
+        (parameters
+          (parameter
+            name: (variable)))
+        body: (compound_statement)))))
+
+==========================
+Lambda with lambda arg
+==========================
+
+((function(): void) $test): void ==> {
+};
+
+(  ( /*test*/ function ( ) : void ) $test ) : void ==> {
+};
+
+(  ( function (  )  /*test*/  : void ) $test ) : void ==> {
+};
+
+// TODO: The line below should not error as it is valid Hack.
+//       See PR #8 for details.
+// (  ( function /*test*/ (  )  : void ) $test ) : void ==> {
+// };
+
+---
+
+(script
+  (expression_statement
+    (lambda_expression
+      (parameters
+        (parameter
+          type: (function_type_specifier
+            return_type: (type_specifier))
+          name: (variable)))
+      return_type: (type_specifier)
+      body: (compound_statement)))
+  (expression_statement
+    (lambda_expression
+      (parameters
+        (parameter
+          type: (function_type_specifier
+            (comment)
+            return_type: (type_specifier))
+          name: (variable)))
+      return_type: (type_specifier)
+      body: (compound_statement)))
+  (expression_statement
+    (lambda_expression
+      (parameters
+        (parameter
+          type: (function_type_specifier
+            (comment)
+            return_type: (type_specifier))
+          name: (variable)))
+      return_type: (type_specifier)
+      body: (compound_statement)))
+  (comment)
+  (comment)
+  (comment)
+  (comment))
+
+==========================
+List
+==========================
+
+list($a) = tuple('a');
+list($a,) = tuple('a','b');
+list($a,,$c) = tuple('a','b','c');
+list(,$b,,,$e,) = tuple('a','b','c','d','e','f');
+
+---
+
+(script
+  (expression_statement
+    (binary_expression
+      left: (list_expression
+        (variable))
+      right: (tuple
+        (string))))
+  (expression_statement
+    (binary_expression
+      left: (list_expression
+        (variable))
+      right: (tuple
+        (string)
+        (string))))
+  (expression_statement
+    (binary_expression
+      left: (list_expression
+        (variable)
+        (variable))
+      right: (tuple
+        (string)
+        (string)
+        (string))))
+  (expression_statement
+    (binary_expression
+      left: (list_expression
+        (variable)
+        (variable))
+      right: (tuple
+        (string)
+        (string)
+        (string)
+        (string)
+        (string)
+        (string)))))
+
+==========================
+New
+==========================
+
+// https://github.com/facebook/hhvm/blob/a114ef79b4673c35755297ed570d23a72969ba5f/hphp/hack/test/full_fidelity/cases/test_object_creation_errors.php
+
+$p1 = new Point();
+$p1 = new Point(12);
+$p1 = new $PointClassVar->$pointClassName();
+
+// Fails in Hack but not in Tree-sitter. Should fail in Tree-sitter.
+// $p1 = new Point::Point(12);
+
+$p1 = new Point::$pointVar(12);
+$p1 = new self::$pointVar(12);
+$p1 = new $point(12);
+$p1 = new Point<int>(12);
+$p1 = new (function_that_returns_class_name())(12);
+$p1 = "Point" |> new $$(12);
+
+---
+
+(script
+  (comment)
+  (expression_statement
+    (binary_expression
+      left: (variable)
+      right: (new_expression
+        (qualified_identifier
+          (identifier))
+        (arguments))))
+  (expression_statement
+    (binary_expression
+      left: (variable)
+      right: (new_expression
+        (qualified_identifier
+          (identifier))
+        (arguments
+          (argument
+            (integer))))))
+  (expression_statement
+    (binary_expression
+      left: (variable)
+      right: (new_expression
+        (selection_expression
+          (variable)
+          (variable))
+        (arguments))))
+  (comment)
+  (comment)
+  (expression_statement
+    (binary_expression
+      left: (variable)
+      right: (new_expression
+        (scoped_identifier
+          (qualified_identifier
+            (identifier))
+          (variable))
+        (arguments
+          (argument
+            (integer))))))
+  (expression_statement
+    (binary_expression
+      left: (variable)
+      right: (new_expression
+        (scoped_identifier
+          (scope_identifier)
+          (variable))
+        (arguments
+          (argument
+            (integer))))))
+  (expression_statement
+    (binary_expression
+      left: (variable)
+      right: (new_expression
+        (variable)
+        (arguments
+          (argument
+            (integer))))))
+  (expression_statement
+    (binary_expression
+      left: (variable)
+      right: (new_expression
+        (qualified_identifier
+          (identifier))
+        (type_arguments
+          (type_specifier))
+        (arguments
+          (argument
+            (integer))))))
+  (expression_statement
+    (binary_expression
+      left: (variable)
+      right: (new_expression
+        (parenthesized_expression
+          (call_expression
+            function: (qualified_identifier
+              (identifier))
+            (arguments)))
+        (arguments
+          (argument
+            (integer))))))
+  (expression_statement
+    (binary_expression
+      left: (variable)
+      right: (binary_expression
+        left: (string)
+        right: (new_expression
+          (pipe_variable)
+          (arguments
+            (argument
+              (integer))))))))
+
+==========================
+Pipe
+==========================
+
+vec[1, 2]
+  |> Vec\map($$, $var ==> $var + 1)
+  |> $_ ==> {
+    return $$;
+  }($$);
+
+---
+
+(script
+  (expression_statement
+    (binary_expression
+      left: (binary_expression
+        left: (array
+          (array_type)
+          (integer)
+          (integer))
+        right: (call_expression
+          function: (qualified_identifier
+            (identifier)
+            (identifier))
+          (arguments
+            (argument
+              (pipe_variable))
+            (argument
+              (lambda_expression
+                (parameters
+                  (parameter
+                    name: (variable)))
+                body: (binary_expression
+                  left: (variable)
+                  right: (integer)))))))
+      right: (call_expression
+        function: (lambda_expression
+          (parameters
+            (parameter
+              name: (variable)))
+          body: (compound_statement
+            (return_statement
+              (pipe_variable))))
+        (arguments
+          (argument
+            (pipe_variable)))))))
+
+==========================
+Pipe scoped
+==========================
+
+C::class |> $$::CONST;
+
+---
+
+(script
+  (expression_statement
+    (binary_expression
+      left: (scoped_identifier
+        (qualified_identifier
+          (identifier))
+        (identifier))
+      right: (scoped_identifier
+        (pipe_variable)
+        (identifier)))))
+
+==========================
+Prefix unary
+==========================
+
+!1;
+~1;
+-1;
++1;
+
+! ~ - +1;
+
+---
+
+(script
+  (expression_statement
+    (prefix_unary_expression
+      operand: (integer)))
+  (expression_statement
+    (prefix_unary_expression
+      operand: (integer)))
+  (expression_statement
+    (prefix_unary_expression
+      operand: (integer)))
+  (expression_statement
+    (prefix_unary_expression
+      operand: (integer)))
+  (expression_statement
+    (prefix_unary_expression
+      operand: (prefix_unary_expression
+        operand: (prefix_unary_expression
+          operand: (prefix_unary_expression
+            operand: (integer)))))))
+
+==========================
+Prefixed strings
+==========================
+
+re"re";
+
+b"b";
+
+r0eb " r 0 eb ";
+
+---
+
+(script
+  (expression_statement
+    (prefixed_string
+      prefix: (identifier)
+      (string)))
+  (expression_statement
+    (prefixed_string
+      prefix: (identifier)
+      (string)))
+  (expression_statement
+    (prefixed_string
+      prefix: (identifier)
+      (string))))
+
+==========================
+Print
+==========================
+
+print 'print';
+
+---
+
+(script
+  (expression_statement
+    (prefix_unary_expression
+      operand: (string))))
+
+==========================
+Require
+==========================
+
+require_once(__DIR__.'/../vendor/autoload.hack');
+require(__DIR__.'/../vendor/autoload.hack');
+
+---
+
+(script
+  (expression_statement
+    (require_expression
+      (parenthesized_expression
+        (binary_expression
+          left: (qualified_identifier
+            (identifier))
+          right: (string)))))
+  (expression_statement
+    (require_expression
+      (parenthesized_expression
+        (binary_expression
+          left: (qualified_identifier
+            (identifier))
+          right: (string))))))
+
+==========================
+Safe selection
+==========================
+
+$var?->$var ?? $var ?->$var ? $var?-> $var : $var ?-> $var;
+
+$var[$var?->$var]?->$var[$var?->$var] ??
+$var[$var ?->$var] ?->$var[$var ?->$var]
+  ? $var[$var?-> $var]?-> $var[$var?-> $var]
+  : $var[$var ?-> $var] ?-> $var[$var ?-> $var];
+
+---
+
+(script
+  (expression_statement
+    (ternary_expression
+      condition: (binary_expression
+        left: (selection_expression
+          (variable)
+          (variable))
+        right: (selection_expression
+          (variable)
+          (variable)))
+      consequence: (selection_expression
+        (variable)
+        (variable))
+      alternative: (selection_expression
+        (variable)
+        (variable))))
+  (expression_statement
+    (ternary_expression
+      condition: (binary_expression
+        left: (subscript_expression
+          (selection_expression
+            (subscript_expression
+              (variable)
+              (selection_expression
+                (variable)
+                (variable)))
+            (variable))
+          (selection_expression
+            (variable)
+            (variable)))
+        right: (subscript_expression
+          (selection_expression
+            (subscript_expression
+              (variable)
+              (selection_expression
+                (variable)
+                (variable)))
+            (variable))
+          (selection_expression
+            (variable)
+            (variable))))
+      consequence: (subscript_expression
+        (selection_expression
+          (subscript_expression
+            (variable)
+            (selection_expression
+              (variable)
+              (variable)))
+          (variable))
+        (selection_expression
+          (variable)
+          (variable)))
+      alternative: (subscript_expression
+        (selection_expression
+          (subscript_expression
+            (variable)
+            (selection_expression
+              (variable)
+              (variable)))
+          (variable))
+        (selection_expression
+          (variable)
+          (variable))))))
+
+==========================
+Selection
+==========================
+
+$var->$var;
+C->$var;
+C->C;
+C\C->$var[1]->C;
+$var[0]->$var[0];
+$var[0]->var[0];
+
+---
+
+(script
+  (expression_statement
+    (selection_expression
+      (variable)
+      (variable)))
+  (expression_statement
+    (selection_expression
+      (qualified_identifier
+        (identifier))
+      (variable)))
+  (expression_statement
+    (selection_expression
+      (qualified_identifier
+        (identifier))
+      (qualified_identifier
+        (identifier))))
+  (expression_statement
+    (selection_expression
+      (subscript_expression
+        (selection_expression
+          (qualified_identifier
+            (identifier)
+            (identifier))
+          (variable))
+        (integer))
+      (qualified_identifier
+        (identifier))))
+  (expression_statement
+    (subscript_expression
+      (selection_expression
+        (subscript_expression
+          (variable)
+          (integer))
+        (variable))
+      (integer)))
+  (expression_statement
+    (subscript_expression
+      (selection_expression
+        (subscript_expression
+          (variable)
+          (integer))
+        (qualified_identifier
+          (identifier)))
+      (integer))))
+
+==========================
+Selection brace
+==========================
+
+$dynamic_item->{$primary_key};
+
+$dynamic_item->{$fun->test()};
+
+$dynamic_item->{$primary_key}->{$primary_key2}->{$primary_key3};
+
+$dynamic_item->{$primary_key}->$primary_key2->{$primary_key3};
+
+---
+
+(script
+  (expression_statement
+    (selection_expression
+      (variable)
+      (braced_expression
+        (variable))))
+  (expression_statement
+    (selection_expression
+      (variable)
+      (braced_expression
+        (call_expression
+          function: (selection_expression
+            (variable)
+            (qualified_identifier
+              (identifier)))
+          (arguments)))))
+  (expression_statement
+    (selection_expression
+      (selection_expression
+        (selection_expression
+          (variable)
+          (braced_expression
+            (variable)))
+        (braced_expression
+          (variable)))
+      (braced_expression
+        (variable))))
+  (expression_statement
+    (selection_expression
+      (selection_expression
+        (selection_expression
+          (variable)
+          (braced_expression
+            (variable)))
+        (variable))
+      (braced_expression
+        (variable)))))
+
+==========================
+Selection with as
+==========================
+
+$var as nonnull->test;
+
+$var as nonnull->test();
+
+($var as nonnull)->test;
+
+$var->test as nonnull;
+
+$var->test as nonnull->test2;
+
+---
+
+(script
+  (expression_statement
+    (selection_expression
+      (as_expression
+        left: (variable)
+        right: (type_specifier))
+      (qualified_identifier
+        (identifier))))
+  (expression_statement
+    (call_expression
+      function: (selection_expression
+        (as_expression
+          left: (variable)
+          right: (type_specifier))
+        (qualified_identifier
+          (identifier)))
+      (arguments)))
+  (expression_statement
+    (selection_expression
+      (parenthesized_expression
+        (as_expression
+          left: (variable)
+          right: (type_specifier)))
+      (qualified_identifier
+        (identifier))))
+  (expression_statement
+    (as_expression
+      left: (selection_expression
+        (variable)
+        (qualified_identifier
+          (identifier)))
+      right: (type_specifier)))
+  (expression_statement
+    (selection_expression
+      (as_expression
+        left: (selection_expression
+          (variable)
+          (qualified_identifier
+            (identifier)))
+        right: (type_specifier))
+      (qualified_identifier
+        (identifier)))))
+
+==========================
+Selection with keyword
+==========================
+
+$this->clone();
+
+$this->print();
+
+$this->new();
+
+$this->clone()->new()->print()->$item;
+
+---
+
+(script
+  (expression_statement
+    (call_expression
+      function: (selection_expression
+        (variable)
+        (identifier))
+      (arguments)))
+  (expression_statement
+    (call_expression
+      function: (selection_expression
+        (variable)
+        (identifier))
+      (arguments)))
+  (expression_statement
+    (call_expression
+      function: (selection_expression
+        (variable)
+        (identifier))
+      (arguments)))
+  (expression_statement
+    (selection_expression
+      (call_expression
+        function: (selection_expression
+          (call_expression
+            function: (selection_expression
+              (call_expression
+                function: (selection_expression
+                  (variable)
+                  (identifier))
+                (arguments))
+              (identifier))
+            (arguments))
+          (identifier))
+        (arguments))
+      (variable))))
+
+==========================
+Shape
+==========================
+
+shape(
+  'field' => 1,
+);
+
+---
+
+(script
+  (expression_statement
+    (shape
+      (field_initializer
+        (string)
+        (integer)))))
+
+==========================
+Shape type keys
+==========================
+
+type square = shape(
+  new C() => C,
+  fun() => int,
+  'streng' => string,
+  (() ==> $var ==> $var)() => string,
+);
+
+---
+
+(script
+  (alias_declaration
+    (identifier)
+    (shape_type_specifier
+      (field_specifier
+        (new_expression
+          (qualified_identifier
+            (identifier))
+          (arguments))
+        (type_specifier
+          (qualified_identifier
+            (identifier))))
+      (field_specifier
+        (call_expression
+          function: (qualified_identifier
+            (identifier))
+          (arguments))
+        (type_specifier))
+      (field_specifier
+        (string)
+        (type_specifier))
+      (field_specifier
+        (call_expression
+          function: (parenthesized_expression
+            (lambda_expression
+              (parameters)
+              body: (lambda_expression
+                (parameters
+                  (parameter
+                    name: (variable)))
+                body: (variable))))
+          (arguments))
+        (type_specifier)))))
+
+==========================
+Subscript as
+==========================
+
+vec[] as int[0];
+
+1 as int[0];
+
+---
+
+(script
+  (expression_statement
+    (subscript_expression
+      (as_expression
+        left: (array
+          (array_type))
+        right: (type_specifier))
+      (integer)))
+  (expression_statement
+    (subscript_expression
+      (as_expression
+        left: (integer)
+        right: (type_specifier))
+      (integer))))
+
+==========================
+Ternary
+==========================
+
+$var ? true : false;
+$var ?: false;
+$var == 1 ? $var ?: 3 : $var > 2 ? 2 : 1;
+$var == 1 ?: $var < 3 ? 3 : 2;
+
+---
+
+(script
+  (expression_statement
+    (ternary_expression
+      condition: (variable)
+      consequence: (true)
+      alternative: (false)))
+  (expression_statement
+    (binary_expression
+      left: (variable)
+      right: (false)))
+  (expression_statement
+    (ternary_expression
+      condition: (ternary_expression
+        condition: (binary_expression
+          left: (variable)
+          right: (integer))
+        consequence: (binary_expression
+          left: (variable)
+          right: (integer))
+        alternative: (binary_expression
+          left: (variable)
+          right: (integer)))
+      consequence: (integer)
+      alternative: (integer)))
+  (expression_statement
+    (ternary_expression
+      condition: (binary_expression
+        left: (binary_expression
+          left: (variable)
+          right: (integer))
+        right: (binary_expression
+          left: (variable)
+          right: (integer)))
+      consequence: (integer)
+      alternative: (integer))))
+
+==========================
+Type arguments
+==========================
+
+funcshion<Cluss<int>, int>();
+
+funcshion<>();
+
+new Cluss<int>();
+
+# Weird. Hack allows empty type arguments on function calls but not class instantiation.
+# new Cluss<>();
+# new Cluss<Cluss<>>();
+
+---
+
+(script
+  (expression_statement
+    (call_expression
+      function: (qualified_identifier
+        (identifier))
+      (type_arguments
+        (type_specifier
+          (qualified_identifier
+            (identifier))
+          (type_arguments
+            (type_specifier)))
+        (type_specifier))
+      (arguments)))
+  (expression_statement
+    (call_expression
+      function: (qualified_identifier
+        (identifier))
+      (type_arguments)
+      (arguments)))
+  (expression_statement
+    (new_expression
+      (qualified_identifier
+        (identifier))
+      (type_arguments
+        (type_specifier))
+      (arguments)))
+  (comment)
+  (comment)
+  (comment))
+
+==========================
+Update
+==========================
+
+++$var;
+--$var;
+$var++;
+$var--;
+
+---
+
+(script
+  (expression_statement
+    (prefix_unary_expression
+      operand: (variable)))
+  (expression_statement
+    (prefix_unary_expression
+      operand: (variable)))
+  (expression_statement
+    (postfix_unary_expression
+      (variable)))
+  (expression_statement
+    (postfix_unary_expression
+      (variable))))
+
+==========================
+Vec
+==========================
+
+vec[];
+vec[1, 1., true];
+
+---
+
+(script
+  (expression_statement
+    (array
+      (array_type)))
+  (expression_statement
+    (array
+      (array_type)
+      (integer)
+      (float)
+      (true))))
+
+==========================
+Weird selection
+==========================
+
+c::c?->c;
+
+($var + $var)?->c;
+
+$func()?->c;
+
+---
+
+(script
+  (expression_statement
+    (selection_expression
+      (scoped_identifier
+        (qualified_identifier
+          (identifier))
+        (identifier))
+      (qualified_identifier
+        (identifier))))
+  (expression_statement
+    (selection_expression
+      (parenthesized_expression
+        (binary_expression
+          left: (variable)
+          right: (variable)))
+      (qualified_identifier
+        (identifier))))
+  (expression_statement
+    (selection_expression
+      (call_expression
+        function: (variable)
+        (arguments))
+      (qualified_identifier
+        (identifier)))))
+
+==========================
+Xhp as arg v3
+==========================
+
+TestXHP::display(<:page:subpage:test />);
+
+---
+
+(script
+  (expression_statement
+    (call_expression
+      function: (scoped_identifier
+        (qualified_identifier
+          (identifier))
+        (identifier))
+      (arguments
+        (argument
+          (xhp_expression
+            (xhp_open_close
+              (xhp_class_identifier))))))))
+
+==========================
+Xhp as arg v4
+==========================
+
+TestXHP::display(<page:subpage:test />);
+
+---
+
+(script
+  (expression_statement
+    (call_expression
+      function: (scoped_identifier
+        (qualified_identifier
+          (identifier))
+        (identifier))
+      (arguments
+        (argument
+          (xhp_expression
+            (xhp_open_close
+              (xhp_identifier))))))))
+
+==========================
+Xhp attribute
+==========================
+
+<frag info={get_str('info')} />;
+
+<frag info={get_str('info')}> </frag>;
+
+<test:attribute_types
+        mystring="foo"
+        mybool={true}
+        myint={123}
+        myarray={varray[1, 2, 3]}
+        myobject={new stdClass()}
+        myenum={'foo'}
+        myfloat={1.23}
+        myvector={Vector {'1', '2', '3'}}
+        mymap={Map {'herp' => 'derp'}}
+        myshape={shape('foo' => 'herp', 'bar' => 'derp')}
+      />;
+
+---
+
+(script
+  (expression_statement
+    (xhp_expression
+      (xhp_open_close
+        (xhp_identifier)
+        (xhp_attribute
+          (xhp_identifier)
+          (braced_expression
+            (call_expression
+              function: (qualified_identifier
+                (identifier))
+              (arguments
+                (argument
+                  (string)))))))))
+  (expression_statement
+    (xhp_expression
+      (xhp_open
+        (xhp_identifier)
+        (xhp_attribute
+          (xhp_identifier)
+          (braced_expression
+            (call_expression
+              function: (qualified_identifier
+                (identifier))
+              (arguments
+                (argument
+                  (string)))))))
+      (xhp_string)
+      (xhp_close
+        (xhp_identifier))))
+  (expression_statement
+    (xhp_expression
+      (xhp_open_close
+        (xhp_identifier)
+        (xhp_attribute
+          (xhp_identifier)
+          (string))
+        (xhp_attribute
+          (xhp_identifier)
+          (braced_expression
+            (true)))
+        (xhp_attribute
+          (xhp_identifier)
+          (braced_expression
+            (integer)))
+        (xhp_attribute
+          (xhp_identifier)
+          (braced_expression
+            (array
+              (array_type)
+              (integer)
+              (integer)
+              (integer))))
+        (xhp_attribute
+          (xhp_identifier)
+          (braced_expression
+            (new_expression
+              (qualified_identifier
+                (identifier))
+              (arguments))))
+        (xhp_attribute
+          (xhp_identifier)
+          (braced_expression
+            (string)))
+        (xhp_attribute
+          (xhp_identifier)
+          (braced_expression
+            (float)))
+        (xhp_attribute
+          (xhp_identifier)
+          (braced_expression
+            (collection
+              (qualified_identifier
+                (identifier))
+              (string)
+              (string)
+              (string))))
+        (xhp_attribute
+          (xhp_identifier)
+          (braced_expression
+            (collection
+              (qualified_identifier
+                (identifier))
+              (element_initializer
+                (string)
+                (string)))))
+        (xhp_attribute
+          (xhp_identifier)
+          (braced_expression
+            (shape
+              (field_initializer
+                (string)
+                (string))
+              (field_initializer
+                (string)
+                (string)))))))))
+
+==========================
+Xhp brace
+==========================
+
+return <frag>
+    Hi! {$this} is a {$this->test()}!
+</frag>;
+
+---
+
+(script
+  (return_statement
+    (xhp_expression
+      (xhp_open
+        (xhp_identifier))
+      (xhp_string)
+      (braced_expression
+        (variable))
+      (xhp_string)
+      (braced_expression
+        (call_expression
+          function: (selection_expression
+            (variable)
+            (qualified_identifier
+              (identifier)))
+          (arguments)))
+      (xhp_string)
+      (xhp_close
+        (xhp_identifier)))))
+
+==========================
+Xhp class v3
+==========================
+
+xhp class :a:m_b {
+}
+
+new :a:m_b:b_m();
+
+---
+
+(script
+  (class_declaration
+    (xhp_modifier)
+    name: (xhp_class_identifier)
+    body: (member_declarations))
+  (expression_statement
+    (new_expression
+      (xhp_class_identifier)
+      (arguments))))
+
+==========================
+Xhp class v4
+==========================
+
+xhp class a:m_b {
+}
+
+new a:m_b:b_m();
+
+---
+
+(script
+  (class_declaration
+    (xhp_modifier)
+    name: (xhp_identifier)
+    body: (member_declarations))
+  (expression_statement
+    (new_expression
+      (xhp_identifier)
+      (arguments))))
+
+==========================
+Xhp classname
+==========================
+
+assert_func(:page:subpage:test::class);
+
+---
+
+(script
+  (expression_statement
+    (call_expression
+      function: (qualified_identifier
+        (identifier))
+      (arguments
+        (argument
+          (scoped_identifier
+            (xhp_class_identifier)
+            (identifier)))))))
+
+==========================
+Xhp comment
+==========================
+
+return <frag>
+    <!--  co--mm->e>nt
+    one  -->
+    Te{$this}st
+    <!--  comment two  -->
+</frag>;
+
+---
+
+(script
+  (return_statement
+    (xhp_expression
+      (xhp_open
+        (xhp_identifier))
+      (xhp_string)
+      (xhp_comment)
+      (xhp_string)
+      (braced_expression
+        (variable))
+      (xhp_string)
+      (xhp_comment)
+      (xhp_string)
+      (xhp_close
+        (xhp_identifier)))))
+
+==========================
+Xhp enum
+==========================
+
+class :a {
+  attribute enum {'a', 'b', 1} denum = 1 @required;
+}
+
+---
+
+(script
+  (class_declaration
+    name: (xhp_class_identifier)
+    body: (member_declarations
+      (xhp_attribute_declaration
+        (xhp_class_attribute
+          type: (xhp_enum_type
+            (string)
+            (string)
+            (integer))
+          name: (xhp_identifier)
+          default: (integer))))))
+
+==========================
+Xhp spread
+==========================
+
+<div {...$this}></div>;
+<div {...$this} id="id1" class="class1"></div>;
+<div id="id1" {...$this} class="class1">{$this}</div>;
+<div id="id1" class="class1" {...$this}>{$this}</div>;
+
+---
+
+(script
+  (expression_statement
+    (xhp_expression
+      (xhp_open
+        (xhp_identifier)
+        (xhp_attribute
+          (xhp_spread_expression
+            (variable))))
+      (xhp_close
+        (xhp_identifier))))
+  (expression_statement
+    (xhp_expression
+      (xhp_open
+        (xhp_identifier)
+        (xhp_attribute
+          (xhp_spread_expression
+            (variable)))
+        (xhp_attribute
+          (xhp_identifier)
+          (string))
+        (xhp_attribute
+          (xhp_identifier)
+          (string)))
+      (xhp_close
+        (xhp_identifier))))
+  (expression_statement
+    (xhp_expression
+      (xhp_open
+        (xhp_identifier)
+        (xhp_attribute
+          (xhp_identifier)
+          (string))
+        (xhp_attribute
+          (xhp_spread_expression
+            (variable)))
+        (xhp_attribute
+          (xhp_identifier)
+          (string)))
+      (braced_expression
+        (variable))
+      (xhp_close
+        (xhp_identifier))))
+  (expression_statement
+    (xhp_expression
+      (xhp_open
+        (xhp_identifier)
+        (xhp_attribute
+          (xhp_identifier)
+          (string))
+        (xhp_attribute
+          (xhp_identifier)
+          (string))
+        (xhp_attribute
+          (xhp_spread_expression
+            (variable))))
+      (braced_expression
+        (variable))
+      (xhp_close
+        (xhp_identifier)))))
+
+==========================
+Xhp string not comment
+==========================
+
+<body> # </body>;
+
+<body> 
+# 
+</body>;
+
+<body> // </body>;
+
+<body> #hello </body>;
+
+<body>#hello</body>;
+
+---
+
+(script
+  (expression_statement
+    (xhp_expression
+      (xhp_open
+        (xhp_identifier))
+      (xhp_string)
+      (xhp_close
+        (xhp_identifier))))
+  (expression_statement
+    (xhp_expression
+      (xhp_open
+        (xhp_identifier))
+      (xhp_string)
+      (xhp_close
+        (xhp_identifier))))
+  (expression_statement
+    (xhp_expression
+      (xhp_open
+        (xhp_identifier))
+      (xhp_string)
+      (xhp_close
+        (xhp_identifier))))
+  (expression_statement
+    (xhp_expression
+      (xhp_open
+        (xhp_identifier))
+      (xhp_string)
+      (xhp_close
+        (xhp_identifier))))
+  (expression_statement
+    (xhp_expression
+      (xhp_open
+        (xhp_identifier))
+      (xhp_string)
+      (xhp_close
+        (xhp_identifier)))))
+
+==========================
+Yield
+==========================
+
+function func(): void {
+  yield 'yield';
+  yield yield 'yield' => 1;
+  yield 1 => 'yield';
+}
+
+---
+
+(script
+  (function_declaration
+    name: (identifier)
+    (parameters)
+    return_type: (type_specifier)
+    body: (compound_statement
+      (expression_statement
+        (yield_expression
+          (string)))
+      (expression_statement
+        (yield_expression
+          (yield_expression
+            (element_initializer
+              (string)
+              (integer)))))
+      (expression_statement
+        (yield_expression
+          (element_initializer
+            (integer)
+            (string)))))))

--- a/test/corpus/literals.txt
+++ b/test/corpus/literals.txt
@@ -1,0 +1,491 @@
+==========================
+Double quoted strings
+==========================
+
+"";
+" ";
+"\"";
+"\\";
+"\?";
+"'";
+" \'\\\?'";
+b" \'\\\?'";
+re" \'\\\?'";
+
+---
+
+(script
+  (expression_statement
+    (string))
+  (expression_statement
+    (string))
+  (expression_statement
+    (string))
+  (expression_statement
+    (string))
+  (expression_statement
+    (string))
+  (expression_statement
+    (string))
+  (expression_statement
+    (string))
+  (expression_statement
+    (prefixed_string
+      prefix: (identifier)
+      (string)))
+  (expression_statement
+    (prefixed_string
+      prefix: (identifier)
+      (string))))
+
+==========================
+Floats
+==========================
+
+12.01;
+.01;
+12.;
+12.01e12;
+12.01E12;
+12.e12;
+12.E12;
+12.01e-12;
+12.01E-12;
+12.e-12;
+12.E-12;
+.01E-12;
+12.01e+12;
+12.01E+12;
+12.e+12;
+12.E+12;
+.01E+12;
+1E12;
+1e12;
+1E-12;
+1e+12;
+
+---
+
+(script
+  (expression_statement
+    (float))
+  (expression_statement
+    (float))
+  (expression_statement
+    (float))
+  (expression_statement
+    (float))
+  (expression_statement
+    (float))
+  (expression_statement
+    (float))
+  (expression_statement
+    (float))
+  (expression_statement
+    (float))
+  (expression_statement
+    (float))
+  (expression_statement
+    (float))
+  (expression_statement
+    (float))
+  (expression_statement
+    (float))
+  (expression_statement
+    (float))
+  (expression_statement
+    (float))
+  (expression_statement
+    (float))
+  (expression_statement
+    (float))
+  (expression_statement
+    (float))
+  (expression_statement
+    (float))
+  (expression_statement
+    (float))
+  (expression_statement
+    (float))
+  (expression_statement
+    (float)))
+
+==========================
+Heredoc almost
+==========================
+
+<<<EOF
+EOFEOF
+EOF;
+
+<<<EOF
+EOFE
+EOF;
+
+<<<EOF
+OFE
+EOF;
+
+
+
+
+---
+
+(script
+  (expression_statement
+    (heredoc))
+  (expression_statement
+    (heredoc))
+  (expression_statement
+    (heredoc)))
+
+==========================
+Heredoc almost concat
+==========================
+
+<<<EOF
+EOFEOF
+EOF.
+<<<EOF
+EOFEOF
+EOF;
+
+<<<EOF
+EOFEOF
+EOF.<<<EOF
+EOFEOF
+EOF;
+
+---
+
+(script
+  (expression_statement
+    (heredoc))
+  (expression_statement
+    (heredoc)))
+
+==========================
+Heredoc brace
+==========================
+
+<<<EOF
+1{$var}2{$var}3{$var}4{$var}
+EOF;
+
+---
+
+(script
+  (expression_statement
+    (heredoc
+      (embedded_brace_expression
+        (variable))
+      (embedded_brace_expression
+        (variable))
+      (embedded_brace_expression
+        (variable))
+      (embedded_brace_expression
+        (variable)))))
+
+==========================
+Heredoc concat
+==========================
+
+<<<EOF
+EOFEOF
+EOF
+.
+<<<EOF
+EOFEOF
+EOF;
+
+---
+
+(script
+  (expression_statement
+    (binary_expression
+      left: (heredoc)
+      right: (heredoc))))
+
+==========================
+Heredoc consecutive
+==========================
+
+<<<EOF
+Heredoc
+EOF;
+
+<<<EOF
+Heredoc
+EOF;
+
+
+---
+
+(script
+  (expression_statement
+    (heredoc))
+  (expression_statement
+    (heredoc)))
+
+==========================
+Heredoc dollar
+==========================
+
+<<<EOT
+	$('a') abc $(function{return;})
+EOT;
+
+---
+
+(script
+  (expression_statement
+    (heredoc)))
+
+==========================
+Heredoc dollar embedded var
+==========================
+
+// This tests that the parser is correctly interprets when a variable is embedded between two string literals
+
+<<<EOT
+	$()abc$()$realvar$()
+EOT;
+
+---
+
+(script
+  (comment) 
+  (expression_statement
+    (heredoc
+      (variable))))
+
+==========================
+Heredoc dollar no lead space
+==========================
+
+<<<EOT
+$()
+EOT;
+
+---
+
+(script
+  (expression_statement
+    (heredoc)))
+
+==========================
+Heredoc double quote
+==========================
+
+<<<"EOF"
+Heredoc
+EOF;
+
+<<<"EOF"
+Heredoc $var
+EOF;
+
+
+---
+
+(script
+  (expression_statement
+    (heredoc))
+  (expression_statement
+    (heredoc
+      (variable))))
+
+==========================
+Heredoc empty
+==========================
+
+<<<EOF
+EOF;
+
+<<<EOF
+EOF;
+
+---
+
+(script
+  (expression_statement
+    (heredoc))
+  (expression_statement
+    (heredoc)))
+
+==========================
+Heredoc simple
+==========================
+
+<<<EOF
+Heredoc
+EOF;
+
+---
+
+(script
+  (expression_statement
+    (heredoc)))
+
+==========================
+Heredoc variable
+==========================
+
+// This test ensures that variables within heredocs are interpreted as such.
+// ÿ is 255 in unicode which is a valid variable identifier.
+
+<<<EOF
+r$var
+EOF;
+
+<<<EOT
+ $ÿ
+EOT;
+
+<<<EOF
+E$var
+EOF;
+
+<<<EOF
+$var
+EOF;
+
+<<<EOF
+$var
+
+EOF;
+
+<<<EOF
+$var
+abc
+EOF;
+
+<<<EOF
+$var x $var
+EOF;
+
+---
+
+(script
+  (comment)
+  (comment)
+  (expression_statement
+    (heredoc
+      (variable)))
+  (expression_statement
+    (heredoc
+      (variable)))
+  (expression_statement
+    (heredoc
+      (variable)))
+  (expression_statement
+    (heredoc
+      (variable)))
+  (expression_statement
+    (heredoc
+      (variable)))
+  (expression_statement
+    (heredoc
+      (variable)))
+  (expression_statement
+    (heredoc
+      (variable)
+      (variable))))
+
+==========================
+Integers
+==========================
+
+1;
+17;
+07;
+0x1A;
+0X1A;
+0b01;
+0B01;
+
+---
+
+(script
+  (expression_statement
+    (integer))
+  (expression_statement
+    (integer))
+  (expression_statement
+    (integer))
+  (expression_statement
+    (integer))
+  (expression_statement
+    (integer))
+  (expression_statement
+    (integer))
+  (expression_statement
+    (integer)))
+
+==========================
+Nowdoc no interpolation
+==========================
+
+<<<'EOF'
+Nowdoc $var Nodoc {$var}
+EOF;
+
+---
+
+(script
+  (expression_statement
+    (heredoc)))
+
+==========================
+Nowdoc simple
+==========================
+
+<<<'EOF'
+Nowdoc
+EOF;
+
+---
+
+(script
+  (expression_statement
+    (heredoc)))
+
+==========================
+Single quoted strings
+==========================
+
+'';
+' ';
+'\'';
+'\\';
+'\?';
+'"';
+' \'\\\?"';
+b' \'\\\?"';
+re' \'\\\?"';
+
+---
+
+(script
+  (expression_statement
+    (string))
+  (expression_statement
+    (string))
+  (expression_statement
+    (string))
+  (expression_statement
+    (string))
+  (expression_statement
+    (string))
+  (expression_statement
+    (string))
+  (expression_statement
+    (string))
+  (expression_statement
+    (prefixed_string
+      prefix: (identifier)
+      (string)))
+  (expression_statement
+    (prefixed_string
+      prefix: (identifier)
+      (string))))

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -1,0 +1,1004 @@
+==========================
+As foreach
+==========================
+
+/**
+ * This test captures that without parenthesis, you might expect this test's code to
+ * parse like this
+ *
+ *     foreach (($array as vec[]) as $item) {}
+ *
+ * but ends up parsing like this (which makes it a parse error).
+ *
+ *     foreach ($array as (vec[] as $item)) {}
+ */
+
+foreach (($array as vec[]) as $item) {}
+
+# Our expectation test for the code below intentionally includes an ERROR.
+foreach ($array as vec[] as $item) {}
+
+---
+
+(script
+  (comment)
+  (foreach_statement
+    collection: (parenthesized_expression
+      (subscript_expression
+        (as_expression
+          left: (variable)
+          right: (type_specifier))))
+    value: (variable)
+    body: (compound_statement))
+  (comment)
+  (foreach_statement
+    collection: (variable)
+    (ERROR
+      (array
+        (array_type)))
+    value: (variable)
+    body: (compound_statement)))
+
+==========================
+Binary foreach
+==========================
+
+foreach ($array ?? vec[] as $item) {}
+
+---
+
+(script
+  (foreach_statement
+    collection: (binary_expression
+      left: (variable)
+      right: (array
+        (array_type)))
+    value: (variable)
+    body: (compound_statement)))
+
+==========================
+Concurrent
+==========================
+
+concurrent {
+  await func1();
+  await func2();
+}
+
+concurrent {
+  await func1();
+  await async {
+    await func2();
+  };
+}
+
+---
+
+(script
+  (concurrent_statement
+    (compound_statement
+      (expression_statement
+        (prefix_unary_expression
+          operand: (call_expression
+            function: (qualified_identifier
+              (identifier))
+            (arguments))))
+      (expression_statement
+        (prefix_unary_expression
+          operand: (call_expression
+            function: (qualified_identifier
+              (identifier))
+            (arguments))))))
+  (concurrent_statement
+    (compound_statement
+      (expression_statement
+        (prefix_unary_expression
+          operand: (call_expression
+            function: (qualified_identifier
+              (identifier))
+            (arguments))))
+      (expression_statement
+        (prefix_unary_expression
+          operand: (awaitable_expression
+            (compound_statement
+              (expression_statement
+                (prefix_unary_expression
+                  operand: (call_expression
+                    function: (qualified_identifier
+                      (identifier))
+                    (arguments)))))))))))
+
+==========================
+Do
+==========================
+
+do 1; while (0);
+
+do { 1; } while (0);
+
+---
+
+(script
+  (do_statement
+    body: (expression_statement
+      (integer))
+    condition: (parenthesized_expression
+      (integer)))
+  (do_statement
+    body: (compound_statement
+      (expression_statement
+        (integer)))
+    condition: (parenthesized_expression
+      (integer))))
+
+==========================
+Do nested
+==========================
+
+do do 1; while (0); while (0);
+
+do { do 1; while (0); } while (0);
+
+do { do { 1; } while (0); } while (0);
+
+---
+
+(script
+  (do_statement
+    body: (do_statement
+      body: (expression_statement
+        (integer))
+      condition: (parenthesized_expression
+        (integer)))
+    condition: (parenthesized_expression
+      (integer)))
+  (do_statement
+    body: (compound_statement
+      (do_statement
+        body: (expression_statement
+          (integer))
+        condition: (parenthesized_expression
+          (integer))))
+    condition: (parenthesized_expression
+      (integer)))
+  (do_statement
+    body: (compound_statement
+      (do_statement
+        body: (compound_statement
+          (expression_statement
+            (integer)))
+        condition: (parenthesized_expression
+          (integer))))
+    condition: (parenthesized_expression
+      (integer))))
+
+==========================
+Echo
+==========================
+
+echo 1;
+
+echo 1, 2, 3;
+
+---
+
+(script
+  (echo_statement
+    (integer))
+  (echo_statement
+    (integer)
+    (integer)
+    (integer)))
+
+==========================
+For
+==========================
+
+for (;;) 1;
+
+for ($var = 1; $var > 0; $var++) 1;
+
+for ($var = 1, $var / 0; $var++, $var > 0; $var--, $var = rand()) 1;
+
+---
+
+(script
+  (for_statement
+    body: (expression_statement
+      (integer)))
+  (for_statement
+    (binary_expression
+      left: (variable)
+      right: (integer))
+    (binary_expression
+      left: (variable)
+      right: (integer))
+    (postfix_unary_expression
+      (variable))
+    body: (expression_statement
+      (integer)))
+  (for_statement
+    (binary_expression
+      left: (variable)
+      right: (integer))
+    (binary_expression
+      left: (variable)
+      right: (integer))
+    (postfix_unary_expression
+      (variable))
+    (binary_expression
+      left: (variable)
+      right: (integer))
+    (postfix_unary_expression
+      (variable))
+    (binary_expression
+      left: (variable)
+      right: (call_expression
+        function: (qualified_identifier
+          (identifier))
+        (arguments)))
+    body: (expression_statement
+      (integer))))
+
+==========================
+Foreach
+==========================
+
+foreach ($c as $v) {}
+
+foreach (varray[] as $k => $v[0]) {}
+
+foreach (darray<int, int>[] as list($a[vec[] as int[0]], $b)) {}
+
+# HHVM can't parse an as-expression in the collection position, but
+# tree-sitter-hack can 💪. Commenting out because bin/test-corpus runs tests for both.
+# foreach (darray<int, int>[] as dict<int, int> as $v) {}
+
+---
+
+(script
+  (foreach_statement
+    collection: (variable)
+    value: (variable)
+    body: (compound_statement))
+  (foreach_statement
+    collection: (array
+      (array_type))
+    key: (variable)
+    value: (subscript_expression
+      (variable)
+      (integer))
+    body: (compound_statement))
+  (foreach_statement
+    collection: (array
+      (array_type)
+      (type_arguments
+        (type_specifier)
+        (type_specifier)))
+    value: (list_expression
+      (subscript_expression
+        (variable)
+        (subscript_expression
+          (as_expression
+            left: (array
+              (array_type))
+            right: (type_specifier))
+          (integer)))
+      (variable))
+    body: (compound_statement))
+  (comment)
+  (comment)
+  (comment))
+
+==========================
+Foreach await
+==========================
+
+foreach ($c await as $v) {}
+
+foreach ($c await as $k => $v) {}
+
+---
+
+(script
+  (foreach_statement
+    collection: (variable)
+    (await_modifier)
+    value: (variable)
+    body: (compound_statement))
+  (foreach_statement
+    collection: (variable)
+    (await_modifier)
+    key: (variable)
+    value: (variable)
+    body: (compound_statement)))
+
+==========================
+If
+==========================
+
+if (0) 1;
+
+if (0) { 1; }
+
+---
+
+(script
+  (if_statement
+    condition: (parenthesized_expression
+      (integer))
+    body: (expression_statement
+      (integer)))
+  (if_statement
+    condition: (parenthesized_expression
+      (integer))
+    body: (compound_statement
+      (expression_statement
+        (integer)))))
+
+==========================
+If else
+==========================
+
+if (0) 1; else 0;
+
+if (0) {
+  1;
+} else {
+  0;
+}
+
+---
+
+(script
+  (if_statement
+    condition: (parenthesized_expression
+      (integer))
+    body: (expression_statement
+      (integer))
+    else: (expression_statement
+      (integer)))
+  (if_statement
+    condition: (parenthesized_expression
+      (integer))
+    body: (compound_statement
+      (expression_statement
+        (integer)))
+    else: (compound_statement
+      (expression_statement
+        (integer)))))
+
+==========================
+If else if
+==========================
+
+if (0) 1; else if (1) 0; elseif (0) 1; else 0;
+
+if (0) {
+} else if (1) {
+} elseif (1) {
+} else {
+}
+
+---
+
+(script
+  (if_statement
+    condition: (parenthesized_expression
+      (integer))
+    body: (expression_statement
+      (integer))
+    condition: (parenthesized_expression
+      (integer))
+    body: (expression_statement
+      (integer))
+    condition: (parenthesized_expression
+      (integer))
+    body: (expression_statement
+      (integer))
+    else: (expression_statement
+      (integer)))
+  (if_statement
+    condition: (parenthesized_expression
+      (integer))
+    body: (compound_statement)
+    condition: (parenthesized_expression
+      (integer))
+    body: (compound_statement)
+    condition: (parenthesized_expression
+      (integer))
+    body: (compound_statement)
+    else: (compound_statement)))
+
+==========================
+If nested
+==========================
+
+if (0) if (1) 0; else 0;
+
+if (0) {
+  if (1) 0;
+} else {
+  if (1) { 0; }
+}
+
+---
+
+(script
+  (if_statement
+    condition: (parenthesized_expression
+      (integer))
+    body: (if_statement
+      condition: (parenthesized_expression
+        (integer))
+      body: (expression_statement
+        (integer))
+      else: (expression_statement
+        (integer))))
+  (if_statement
+    condition: (parenthesized_expression
+      (integer))
+    body: (compound_statement
+      (if_statement
+        condition: (parenthesized_expression
+          (integer))
+        body: (expression_statement
+          (integer))))
+    else: (compound_statement
+      (if_statement
+        condition: (parenthesized_expression
+          (integer))
+        body: (compound_statement
+          (expression_statement
+            (integer)))))))
+
+==========================
+Switch
+==========================
+
+switch ($arg) {default:}
+
+---
+
+(script
+  (switch_statement
+    value: (parenthesized_expression
+      (variable))
+    (switch_default)))
+
+==========================
+Switch case
+==========================
+
+switch ($arg) {
+  case 1 + 1:
+    return 1 + 1;
+    break;
+}
+
+---
+
+(script
+  (switch_statement
+    value: (parenthesized_expression
+      (variable))
+    (switch_case
+      value: (binary_expression
+        left: (integer)
+        right: (integer))
+      (return_statement
+        (binary_expression
+          left: (integer)
+          right: (integer)))
+      (break_statement))))
+
+==========================
+Switch default
+==========================
+
+switch ($arg) {
+  default:
+    break;
+  case 1:
+    break;
+}
+
+---
+
+(script
+  (switch_statement
+    value: (parenthesized_expression
+      (variable))
+    (switch_default
+      (break_statement))
+    (switch_case
+      value: (integer)
+      (break_statement))))
+
+==========================
+Throw
+==========================
+
+throw 1;
+
+---
+
+(script
+  (throw_statement
+    (integer)))
+
+==========================
+Try
+==========================
+
+try {
+} catch (Type $var) {
+}
+
+try {
+} catch (Type $var1) {
+} catch (Type $var2) {
+}
+
+---
+
+(script
+  (try_statement
+    body: (compound_statement)
+    (catch_clause
+      type: (type_specifier
+        (qualified_identifier
+          (identifier)))
+      name: (variable)
+      body: (compound_statement)))
+  (try_statement
+    body: (compound_statement)
+    (catch_clause
+      type: (type_specifier
+        (qualified_identifier
+          (identifier)))
+      name: (variable)
+      body: (compound_statement))
+    (catch_clause
+      type: (type_specifier
+        (qualified_identifier
+          (identifier)))
+      name: (variable)
+      body: (compound_statement))))
+
+==========================
+Try catch finally
+==========================
+
+try {
+} catch (Type $var) {
+} finally {
+}
+
+try {
+} catch (Type $var1) {
+} catch (Type $var2) {
+} finally {
+}
+
+---
+
+(script
+  (try_statement
+    body: (compound_statement)
+    (catch_clause
+      type: (type_specifier
+        (qualified_identifier
+          (identifier)))
+      name: (variable)
+      body: (compound_statement))
+    (finally_clause
+      body: (compound_statement)))
+  (try_statement
+    body: (compound_statement)
+    (catch_clause
+      type: (type_specifier
+        (qualified_identifier
+          (identifier)))
+      name: (variable)
+      body: (compound_statement))
+    (catch_clause
+      type: (type_specifier
+        (qualified_identifier
+          (identifier)))
+      name: (variable)
+      body: (compound_statement))
+    (finally_clause
+      body: (compound_statement))))
+
+==========================
+Try finally
+==========================
+
+try {
+} finally {
+}
+
+---
+
+(script
+  (try_statement
+    body: (compound_statement)
+    (finally_clause
+      body: (compound_statement))))
+
+==========================
+Try nested
+==========================
+
+try {
+  try {
+  } catch (Namespce\Type $var) {
+  } finally {
+  }
+} catch (Namespce\Type $var) {
+  try {
+  } catch (Namespce\Type $var) {
+  } finally {
+  }
+} finally {
+  try {
+  } catch (Namespce\Type $var) {
+  } finally {
+  }
+}
+
+---
+
+(script
+  (try_statement
+    body: (compound_statement
+      (try_statement
+        body: (compound_statement)
+        (catch_clause
+          type: (type_specifier
+            (qualified_identifier
+              (identifier)
+              (identifier)))
+          name: (variable)
+          body: (compound_statement))
+        (finally_clause
+          body: (compound_statement))))
+    (catch_clause
+      type: (type_specifier
+        (qualified_identifier
+          (identifier)
+          (identifier)))
+      name: (variable)
+      body: (compound_statement
+        (try_statement
+          body: (compound_statement)
+          (catch_clause
+            type: (type_specifier
+              (qualified_identifier
+                (identifier)
+                (identifier)))
+            name: (variable)
+            body: (compound_statement))
+          (finally_clause
+            body: (compound_statement)))))
+    (finally_clause
+      body: (compound_statement
+        (try_statement
+          body: (compound_statement)
+          (catch_clause
+            type: (type_specifier
+              (qualified_identifier
+                (identifier)
+                (identifier)))
+            name: (variable)
+            body: (compound_statement))
+          (finally_clause
+            body: (compound_statement)))))))
+
+==========================
+Unset
+==========================
+
+unset();
+
+unset($dict['a'], $vec[1]);
+
+---
+
+(script
+  (unset_statement)
+  (unset_statement
+    (subscript_expression
+      (variable)
+      (string))
+    (subscript_expression
+      (variable)
+      (integer))))
+
+==========================
+Use
+==========================
+
+use const Space\Const\C;
+use function Space\Func\F as E;
+use type Space\Type\T;
+use namespace Space\Name\N as M;
+
+use namespace Space\Name2\N2, Space\Nothing\N3 as N8, type Space\Type2\N4,;
+
+use namespace Space\Name\N10\{A as A2, B\};
+use namespace Space\Name\{\C, Slash as Forward};
+
+use \What\Is\This\{function A as A2, B, const H\S\L as stdlib, function F};
+
+use type \{kind,};
+use Q\B\{kind2,};
+use type Q\B\{kind3,};
+
+
+---
+
+(script
+  (use_statement
+    (use_clause
+      (use_type)
+      (qualified_identifier
+        (identifier)
+        (identifier)
+        (identifier))))
+  (use_statement
+    (use_clause
+      (use_type)
+      (qualified_identifier
+        (identifier)
+        (identifier)
+        (identifier))
+      alias: (identifier)))
+  (use_statement
+    (use_clause
+      (use_type)
+      (qualified_identifier
+        (identifier)
+        (identifier)
+        (identifier))))
+  (use_statement
+    (use_clause
+      (use_type)
+      (qualified_identifier
+        (identifier)
+        (identifier)
+        (identifier))
+      alias: (identifier)))
+  (use_statement
+    (use_clause
+      (use_type)
+      (qualified_identifier
+        (identifier)
+        (identifier)
+        (identifier)))
+    (use_clause
+      (qualified_identifier
+        (identifier)
+        (identifier)
+        (identifier))
+      alias: (identifier))
+    (use_clause
+      (use_type)
+      (qualified_identifier
+        (identifier)
+        (identifier)
+        (identifier))))
+  (use_statement
+    (use_type)
+    (qualified_identifier
+      (identifier)
+      (identifier)
+      (identifier))
+    (use_clause
+      (qualified_identifier
+        (identifier))
+      alias: (identifier))
+    (use_clause
+      (qualified_identifier
+        (identifier))))
+  (use_statement
+    (use_type)
+    (qualified_identifier
+      (identifier)
+      (identifier))
+    (use_clause
+      (qualified_identifier
+        (identifier)))
+    (use_clause
+      (qualified_identifier
+        (identifier))
+      alias: (identifier)))
+  (use_statement
+    (qualified_identifier
+      (identifier)
+      (identifier)
+      (identifier))
+    (use_clause
+      (use_type)
+      (qualified_identifier
+        (identifier))
+      alias: (identifier))
+    (use_clause
+      (qualified_identifier
+        (identifier)))
+    (use_clause
+      (use_type)
+      (qualified_identifier
+        (identifier)
+        (identifier)
+        (identifier))
+      alias: (identifier))
+    (use_clause
+      (use_type)
+      (qualified_identifier
+        (identifier))))
+  (use_statement
+    (use_type)
+    (use_clause
+      (qualified_identifier
+        (identifier))))
+  (use_statement
+    (qualified_identifier
+      (identifier)
+      (identifier))
+    (use_clause
+      (qualified_identifier
+        (identifier))))
+  (use_statement
+    (use_type)
+    (qualified_identifier
+      (identifier)
+      (identifier))
+    (use_clause
+      (qualified_identifier
+        (identifier)))))
+
+==========================
+Using
+==========================
+
+using (0) {}
+
+await using (0) {}
+
+---
+
+(script
+  (using_statement
+    (integer)
+    (compound_statement))
+  (using_statement
+    (await_modifier)
+    (integer)
+    (compound_statement)))
+
+==========================
+Using sequence
+==========================
+
+using ($new = new Object(), $file = new File('using', '+using')) {}
+
+---
+
+(script
+  (using_statement
+    (binary_expression
+      left: (variable)
+      right: (new_expression
+        (qualified_identifier
+          (identifier))
+        (arguments)))
+    (binary_expression
+      left: (variable)
+      right: (new_expression
+        (qualified_identifier
+          (identifier))
+        (arguments
+          (argument
+            (string))
+          (argument
+            (string)))))
+    (compound_statement)))
+
+==========================
+Using simple
+==========================
+
+function func(): void {
+  using $new = Object::new();
+}
+
+---
+
+(script
+  (function_declaration
+    name: (identifier)
+    (parameters)
+    return_type: (type_specifier)
+    body: (compound_statement
+      (using_statement
+        (expression_statement
+          (binary_expression
+            left: (variable)
+            right: (call_expression
+              function: (scoped_identifier
+                (qualified_identifier
+                  (identifier))
+                (identifier))
+              (arguments))))))))
+
+==========================
+While
+==========================
+
+while (0) 1;
+
+while (0) { 1; }
+
+---
+
+(script
+  (while_statement
+    condition: (parenthesized_expression
+      (integer))
+    body: (expression_statement
+      (integer)))
+  (while_statement
+    condition: (parenthesized_expression
+      (integer))
+    body: (compound_statement
+      (expression_statement
+        (integer)))))
+
+==========================
+While identifier
+==========================
+
+while (id < 1) {}
+
+---
+
+(script
+  (while_statement
+    condition: (parenthesized_expression
+      (binary_expression
+        left: (qualified_identifier
+          (identifier))
+        right: (integer)))
+    body: (compound_statement)))
+
+==========================
+While nested
+==========================
+
+while (0) while (1) 0;
+
+while (0) { while (1) { 0; } }
+
+---
+
+(script
+  (while_statement
+    condition: (parenthesized_expression
+      (integer))
+    body: (while_statement
+      condition: (parenthesized_expression
+        (integer))
+      body: (expression_statement
+        (integer))))
+  (while_statement
+    condition: (parenthesized_expression
+      (integer))
+    body: (compound_statement
+      (while_statement
+        condition: (parenthesized_expression
+          (integer))
+        body: (compound_statement
+          (expression_statement
+            (integer)))))))


### PR DESCRIPTION
###  Summary

- Tracks corpus file
  - Reasoning: Downstream, ocaml-tree-sitter assumes that corpus tests have been committed to the tree-sitter repo. To test against regressions, it symlinks and runs the tests. See https://github.com/returntocorp/ocaml-tree-sitter-semgrep/blob/cabfe800af79188f69bd7b4380cf54274f6db790/lang/semgrep-grammars/src/prep.common#L27-L36. We want these tests to run.
- Ensures build files are up to date in PRs
  - Reasoning: Will catch any corpus or tree-sitter gen discrepancies


To verify that action is working, reference purposefully failed actions below in 45633b0 (see https://github.com/slackhq/tree-sitter-hack/runs/3284730037). 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/tree-sitter-hack/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).