### PR TITLE
fix: set alias for /function(s)?/ to highlight it as "function"

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -452,7 +452,9 @@ const rules = {
     seq(
       rep($._type_modifier),
       '(',
-      /function\s*\(/,
+      'function',
+      /\s*/,
+      '(',
       opt(com(opt($.inout_modifier), $._type, opt($.variadic_modifier), ',')),
       ')',
       ':',

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2147,8 +2147,16 @@
           "value": "("
         },
         {
+          "type": "STRING",
+          "value": "function"
+        },
+        {
           "type": "PATTERN",
-          "value": "function\\s*\\("
+          "value": "\\s*"
+        },
+        {
+          "type": "STRING",
+          "value": "("
         },
         {
           "type": "CHOICE",


### PR DESCRIPTION
###  Summary

Regexes don't appear in the AST, so in lambdas `"function"` and `"("` can not be highlighted properly.

Solution: replace regex by equivalent tokens.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/tree-sitter-hack/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).