### PR TITLE
Change to using std::string instead of const char*

### DIFF
--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -38,19 +38,19 @@
 
 #define next()                       \
   {                                  \
-    print("next %s\n", str(peek())); \
+    print("next %s\n", str(peek()).c_str()); \
     lexer->advance(lexer, false);    \
   }
 
 #define skip()                       \
   {                                  \
-    print("skip %s\n", str(peek())); \
+    print("skip %s\n", str(peek()).c_str()); \
     lexer->advance(lexer, true);     \
   }
 
 #define stop()                       \
   {                                  \
-    print("stop %s\n", str(peek())); \
+    print("stop %s\n", str(peek()).c_str()); \
     lexer->mark_end(lexer);          \
   }
 
@@ -84,7 +84,7 @@ const char *TokenTypes[] = {
     "HEREDOC_END",            //
 };
 
-static const char *str(int32_t chr) {
+static string str(int32_t chr) {
   switch (chr) {
     case '\n':
       return "\\n";
@@ -103,7 +103,7 @@ static const char *str(int32_t chr) {
 
       string str;
       str += chr;
-      return str.c_str();
+      return str;
   }
 }
 


### PR DESCRIPTION
###  Summary

This update should fix the use-after-free vulnerability reported in #37. While this wasn't exploitable, it's better to remove dangling pointers. We are now returning a string object instead of a pointer to a const char* that no longer exists after exiting the function.

Thank you for your report, @theHamsta!

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/tree-sitter-hack/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).