### PR TITLE
Add syntax highlighting queries

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -1,0 +1,31 @@
+(comment) @comment
+
+(string) @string
+(heredoc) @string
+(prefixed_string) @string
+
+[
+  "class"
+  "interface"
+  "trait"
+  "public"
+  "protected"
+  "private"
+  "static"
+  "async"
+  "function"
+  "return"
+  "if"
+  "else"
+  "elseif"
+  "while"
+  "for"
+  "foreach"
+  "break"
+  "continue"
+  "type"
+  "new"
+  "throw"
+] @keyword
+
+(type_specifier) @type


### PR DESCRIPTION
###  Summary

Add basic syntax highlighting for comments, strings, common keywords
and types.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/tree-sitter-hack/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).