### PR TITLE
Mark treesitter files as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,14 +1,7 @@
 /examples/* linguist-vendored
 
 # Explicitly list files in src so scanner.cc and scanner.c are not included.
-/src/tree_sitter/* linguist-vendored
-/src/binding.cc linguist-vendored
-/src/grammar.json linguist-vendored
-/src/node-types.json linguist-vendored
-/src/parser.c linguist-vendored
-
-/src/tree_sitter/* binary
-/src/binding.cc binary
-/src/grammar.json binary
-/src/node-types.json binary
-/src/parser.c binary
+/src/tree_sitter/* -diff linguist-vendored
+/src/grammar.json -diff linguist-generated
+/src/node-types.json -diff linguist-generated
+/src/parser.c -diff linguist-generated


### PR DESCRIPTION
The treesitter files are autogenerated and are constantly changing, leading to
hundreds of thousands of lines in code review. They are currently marked as
"vendored" however this is for code which was manually written but
automatically checked in. The `generated` attribute should be used instead so
that changes to the files do not appear in code review.

see https://github.com/github/linguist/blob/master/docs/overrides.md and
https://git-scm.com/docs/gitattributes for more info.

test plan:
modify `grammar.js`, run `treesitter generate` and look at diff:
```
$ git diff
diff --git a/grammar.js b/grammar.js
index fc3f9d5..980e927 100644
--- a/grammar.js
+++ b/grammar.js
@@ -117,7 +117,7 @@ const rules = {
       $.unset_statement,
 
       $.use_statement,
-      $.if_statement,
+      //$.if_statement,
       $.while_statement,
       $.do_statement,
       $.for_statement,
diff --git a/src/grammar.json b/src/grammar.json
index 2f7db16..e79c578 100644
Binary files a/src/grammar.json and b/src/grammar.json differ
diff --git a/src/node-types.json b/src/node-types.json
index 4d0bac2..bc9e906 100644
Binary files a/src/node-types.json and b/src/node-types.json differ
diff --git a/src/parser.c b/src/parser.c
index aceb5de..9e41958 100644
Binary files a/src/parser.c and b/src/parser.c differ
diff --git a/src/tree_sitter/parser.h b/src/tree_sitter/parser.h
index cbbc7b4..2b14ac1 100644
Binary files a/src/tree_sitter/parser.h and b/src/tree_sitter/parser.h differ
```

### Requirements (place an `x` in each `[ ]`)

* [x] I've added tests for any new code and ran `npm run test-corpus` to make sure all tests pass.
* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/tree-sitter-hack/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
