### PR TITLE
Add support for expression trees (#58)

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -180,6 +180,7 @@ const rules = {
       $.collection,
       $._literal,
       $._variablish,
+      $.expression_tree,
       $.prefixed_string,
       $.parenthesized_expression,
       $.binary_expression,
@@ -406,6 +407,11 @@ const rules = {
         /"(\\"|\\\\|\\?[^"\\])*"/,
       ),
     ),
+
+  expression_tree: $ => seq(
+    field('visitor', $.identifier),
+    token(/`[^`]*`/),
+  ),
 
   prefixed_string: $ => seq(field('prefix', $.identifier), $.string),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -549,6 +549,10 @@
         },
         {
           "type": "SYMBOL",
+          "name": "expression_tree"
+        },
+        {
+          "type": "SYMBOL",
           "name": "prefixed_string"
         },
         {
@@ -1877,6 +1881,26 @@
           }
         ]
       }
+    },
+    "expression_tree": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "visitor",
+          "content": {
+            "type": "SYMBOL",
+            "name": "identifier"
+          }
+        },
+        {
+          "type": "TOKEN",
+          "content": {
+            "type": "PATTERN",
+            "value": "`[^`]*`"
+          }
+        }
+      ]
     },
     "prefixed_string": {
       "type": "SEQ",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -90,6 +90,10 @@
         "named": true
       },
       {
+        "type": "expression_tree",
+        "named": true
+      },
+      {
         "type": "function_pointer",
         "named": true
       },
@@ -1565,6 +1569,22 @@
           "named": true
         }
       ]
+    }
+  },
+  {
+    "type": "expression_tree",
+    "named": true,
+    "fields": {
+      "visitor": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      }
     }
   },
   {

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -2958,8 +2958,8 @@ Xhp string not comment
 
 <body> # </body>;
 
-<body> 
-# 
+<body>
+#
 </body>;
 
 <body> // </body>;
@@ -3039,3 +3039,28 @@ function func(): void {
           (element_initializer
             (integer)
             (string)))))))
+
+==========================
+Expression tree
+==========================
+
+function func(): int {
+  $result = calc`{ return 1; }`;
+  return $result;
+}
+
+---
+
+(script
+  (function_declaration
+    (identifier)
+    (parameters)
+    (type_specifier)
+    (compound_statement
+      (expression_statement
+        (binary_expression
+          (variable)
+          (expression_tree
+            (identifier))))
+      (return_statement
+        (variable)))))

--- a/test/corpus/literals.txt
+++ b/test/corpus/literals.txt
@@ -511,7 +511,7 @@ EOT;
 ---
 
 (script
-  (comment) 
+  (comment)
   (expression_statement
     (heredoc
       (variable))))
@@ -706,6 +706,34 @@ EOF;
 (script
   (expression_statement
     (heredoc)))
+
+==========================
+Expression tree strings
+==========================
+
+VisitorClass`42`;
+VisitorClass`{ return 1; }`;
+VisitorClass`{ $x = 1; return $x; }`;
+VisitorClass`{
+  $x = 1;
+  return $x;
+}`;
+
+---
+
+(script
+  (expression_statement
+    (expression_tree
+      (identifier)))
+  (expression_statement
+    (expression_tree
+      (identifier)))
+  (expression_statement
+    (expression_tree
+      (identifier)))
+  (expression_statement
+    (expression_tree
+      (identifier))))
 
 ==========================
 Single quoted strings


### PR DESCRIPTION
###  Summary

This diff adds support for module level attributes, such as the following:
```
<?hh

<<file: SomeClass(SomeOtherClass::class)>>
```

### Requirements

* [x] I've added tests for any new code and ran `npm run test-corpus` to make sure all tests pass.
* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/tree-sitter-hack/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
