### PR TITLE
Add support for typed collection initializers (#57)

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -556,6 +556,7 @@ const rules = {
   collection: $ =>
     seq(
       $.qualified_identifier,
+      opt($.type_arguments),
       '{',
       opt(com(choice($._expression, $.element_initializer), ',')),
       '}',
@@ -1270,7 +1271,8 @@ module.exports = grammar({
     [$.binary_expression, $.prefix_unary_expression, $.call_expression],
     [$._expression, $.parameter],
     [$._expression, $.type_specifier],
-    [$._expression, $.type_specifier, $.function_pointer],
+    [$._expression, $.collection, $.type_specifier, $.function_pointer],
+    [$._expression, $.collection, $.function_pointer],
     [$._expression, $.field_initializer],
     [$._expression, $.function_pointer],
     [$.scoped_identifier, $._type_constant],

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3037,6 +3037,18 @@
           "name": "qualified_identifier"
         },
         {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "type_arguments"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
           "type": "STRING",
           "value": "{"
         },
@@ -8634,7 +8646,13 @@
     ],
     [
       "_expression",
+      "collection",
       "type_specifier",
+      "function_pointer"
+    ],
+    [
+      "_expression",
+      "collection",
       "function_pointer"
     ],
     [

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1132,6 +1132,10 @@
         {
           "type": "element_initializer",
           "named": true
+        },
+        {
+          "type": "type_arguments",
+          "named": true
         }
       ]
     }

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -839,12 +839,17 @@ Collection
 
 Vector {};
 HH\Vector {1, 2, 3};
+Vector<string> {};
 
 \HH\Map {};
 Map {'foo' => 1};
 
 Set {};
 Set {'foo', 'bar'};
+Set<string> {'foo', 'bar'};
+Set<classname<SomeClass>> {
+  SomeClass::class
+};
 
 ---
 
@@ -864,6 +869,12 @@ Set {'foo', 'bar'};
   (expression_statement
     (collection
       (qualified_identifier
+        (identifier))
+            (type_arguments
+              (type_specifier))))
+        (expression_statement
+          (collection
+            (qualified_identifier
         (identifier)
         (identifier))))
   (expression_statement
@@ -882,7 +893,31 @@ Set {'foo', 'bar'};
       (qualified_identifier
         (identifier))
       (string)
-      (string))))
+      (string)))
+      (expression_statement
+        (collection
+          (qualified_identifier
+            (identifier))
+          (type_arguments
+            (type_specifier))
+          (string)
+          (string)))
+      (expression_statement
+        (collection
+          (qualified_identifier
+            (identifier))
+          (type_arguments
+            (type_specifier
+              (qualified_identifier
+                (identifier))
+              (type_arguments
+                (type_specifier
+                  (qualified_identifier
+                    (identifier))))))
+          (scoped_identifier
+            (qualified_identifier
+              (identifier))
+              (identifier)))))
 
 ==========================
 Comments


### PR DESCRIPTION
###  Summary

The parser does not recognise typed collection initializers.

This is valid Hack code to generate a vector of strings:
```
$x = Vector<string> {'foo', 'bar'};
```
Yet, the parser does not recognize the syntax and mistakes it for a function pointer:

```
(expression_statement
        (function_pointer
          (qualified_identifier
            (identifier))
          (type_arguments
            (type_specifier)))
        (MISSING ";"))
      (compound_statement
        (ERROR
          (string)
          (string)))
      (empty_statement))
```

This pull request adds support for this syntax.

### Requirements

* [x] I've added tests for any new code and ran `npm run test-corpus` to make sure all tests pass.
* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/tree-sitter-hack/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
