### PR TITLE
Add support for module level attributes (#58)

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -108,6 +108,8 @@ const rules = {
     choice(
       $._declaration,
 
+      $.module_attribute,
+
       $.compound_statement,
       $.empty_statement,
       $.expression_statement,
@@ -144,6 +146,14 @@ const rules = {
       $.namespace_declaration,
       $.const_declaration,
     ),
+
+  module_attribute: $ => seq(
+    '<<',
+    $.identifier,
+    ':',
+    com($.qualified_identifier, opt($.arguments), ','),
+    '>>'
+  ),
 
   heredoc: $ =>
     seq(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -268,6 +268,10 @@
         },
         {
           "type": "SYMBOL",
+          "name": "module_attribute"
+        },
+        {
+          "type": "SYMBOL",
           "name": "compound_statement"
         },
         {
@@ -386,6 +390,88 @@
         {
           "type": "SYMBOL",
           "name": "const_declaration"
+        }
+      ]
+    },
+    "module_attribute": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "<<"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "STRING",
+          "value": ":"
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "qualified_identifier"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "arguments"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "qualified_identifier"
+                  },
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "arguments"
+                      },
+                      {
+                        "type": "BLANK"
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": ","
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": ">>"
         }
       ]
     },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -278,6 +278,10 @@
         "named": true
       },
       {
+        "type": "module_attribute",
+        "named": true
+      },
+      {
         "type": "return_statement",
         "named": true
       },
@@ -2320,6 +2324,29 @@
         },
         {
           "type": "where_clause",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "module_attribute",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "arguments",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "qualified_identifier",
           "named": true
         }
       ]

--- a/test/corpus/declarations.txt
+++ b/test/corpus/declarations.txt
@@ -37,6 +37,26 @@ async ($x) ==> $x + 1;
         right: (integer)))))
 
 ==========================
+Module attribute
+==========================
+
+<<file: SomeClass(SomeOtherClass::class)>>
+
+---
+
+(script
+      (module_attribute
+        (identifier)
+        (qualified_identifier
+          (identifier))
+        (arguments
+          (argument
+            (scoped_identifier
+              (qualified_identifier
+                (identifier))
+              (identifier))))))
+
+==========================
 Attribute
 ==========================
 


### PR DESCRIPTION
###  Summary

This is valid Hack code that declares a module-level attribute:
```
<?hh

<<file: SomeClass(SomeOtherClass::class)>>
```

Yet, the parser does not recognize the syntax:
```
(script
      (ERROR
        (attribute_modifier
          (ERROR
            (identifier))
          (qualified_identifier
            (identifier))
          (arguments
            (argument
              (scoped_identifier
                (qualified_identifier
                  (identifier))
                (identifier)))))))
```

This PR adds support for this syntax.

### Requirements (place an `x` in each `[ ]`)

* [x] I've added tests for any new code and ran `npm run test-corpus` to make sure all tests pass.
* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/tree-sitter-hack/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
