### PR TITLE
Add support for internal visibility modifier

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1091,7 +1091,7 @@ const rules = {
 
   static_modifier: $ => 'static',
 
-  visibility_modifier: $ => choice('public', 'protected', 'private'),
+  visibility_modifier: $ => choice('public', 'protected', 'private', 'internal'),
 
   attribute_modifier: $ =>
     seq('<<', com($.qualified_identifier, opt($.arguments), ','), '>>'),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -7803,6 +7803,10 @@
         {
           "type": "STRING",
           "value": "private"
+        },
+        {
+          "type": "STRING",
+          "value": "internal"
         }
       ]
     },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -4623,6 +4623,10 @@
     "named": false
   },
   {
+    "type": "internal",
+    "named": false
+  },
+  {
     "type": "is",
     "named": false
   },
@@ -4748,11 +4752,11 @@
   },
   {
     "type": "string",
-    "named": true
+    "named": false
   },
   {
     "type": "string",
-    "named": false
+    "named": true
   },
   {
     "type": "super",

--- a/test/corpus/declarations.txt
+++ b/test/corpus/declarations.txt
@@ -3943,6 +3943,7 @@ abstract class C {
   function method3(): void {}
   abstract public static function method4();
   final public static function method5(): void {}
+  internal function method6(): void {}
 }
 
 ---
@@ -3979,6 +3980,12 @@ abstract class C {
         (final_modifier)
         (visibility_modifier)
         (static_modifier)
+        name: (identifier)
+        (parameters)
+        return_type: (type_specifier)
+        body: (compound_statement))
+      (method_declaration
+        (visibility_modifier)
         name: (identifier)
         (parameters)
         return_type: (type_specifier)


### PR DESCRIPTION
###  Summary

Modern Hacklang introduced modules and the [internal visibility modifier](https://docs.hhvm.com/hack/modules/using-internal) to mark methods and functions as only accessible from within the current module.

The Hacklang treesitter grammar doesn't support the internal visibility modifier yet. This diff addresses it.

---

Grammar tests pass:
```
tree-sitter generate
tree-sitter test
```

### Requirements (place an `x` in each `[ ]`)

* [x] I've added tests for any new code and ran `npm run test-corpus` to make sure all tests pass.
* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/tree-sitter-hack/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
